### PR TITLE
0.4.1 / DynaInt Display implementation; needed for Juniper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
 
+## [0.4.1] - 2018-10-19
+### Added
+ - `DynaInt`, initial `std::fmt::Display` implementation
+
+
 ## [0.4.0] - 2018-10-10
 ### Bugs
  - `Hash` implementation for `GenericFraction` now returns equal hashes for negative and positive zeroes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,10 @@ license = "MIT/Apache-2.0"
 
 homepage = "https://github.com/dnsl48/fraction.git"
 repository = "https://github.com/dnsl48/fraction.git"
-documentation = "https://docs.rs/fraction/"
 readme = "README.md"
+
+# TODO: revert to docs.rs when it gets Rust updated
+documentation = "https://dnsl48.github.io/fraction/target/doc/fraction/index.html"  # "https://docs.rs/fraction/"
 
 
 exclude = ["src/tests/division/*"]

--- a/src/dynaint.rs
+++ b/src/dynaint.rs
@@ -29,6 +29,7 @@ use std::mem;
 
 use num::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Integer, Num, One, Zero, ToPrimitive, Bounded};
 use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
+use std::fmt;
 use std::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
     Mul, MulAssign, Neg, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
@@ -71,6 +72,20 @@ where
     T: Copy + GenericInteger + Into<G> + TryToConvertFrom<G> + From<u8>,
     G: Copy + GenericInteger
 {}
+
+
+impl<T, G> fmt::Display for DynaInt<T, G>
+where
+    T: Copy + GenericInteger + Into<G> + TryToConvertFrom<G> + From<u8> + fmt::Display,
+    G: Clone + GenericInteger + fmt::Display,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            DynaInt::S(value) => write!(formatter, "{}", value),
+            DynaInt::__H(value) => write!(formatter, "{}", value)
+        }
+    }
+}
 
 
 impl<T, G> Bounded for DynaInt<T, G>


### PR DESCRIPTION
Juniper implementation for Fraction and Decimal requires `Display` implementation for the base integer type, so if we want to use `DynaInt` as the base, we need the Display to be implemented.