### PR TITLE
Fixed cargo-check complaining about dyn traits.

### DIFF
--- a/src/division.rs
+++ b/src/division.rs
@@ -539,7 +539,7 @@ where
 /// [`divide_rem`]: ./fn.divide_rem.html
 #[inline]
 pub fn divide_to_writeable<I>(
-    writeable: &mut Write,
+    writeable: &mut dyn Write,
     dividend: I,
     divisor: I,
     precision: usize,
@@ -753,7 +753,7 @@ where
 /// assert_eq!(&result, "1.75");
 /// assert_eq!(length, result.len());
 /// ```
-pub fn write_digit(writeable: &mut Write, digit: u8) -> Result<bool, DivisionError>
+pub fn write_digit(writeable: &mut dyn Write, digit: u8) -> Result<bool, DivisionError>
 {
     if digit == 10u8 {
         match writeable.write_char('.') {
@@ -1085,7 +1085,7 @@ mod tests {
 
             {
                 let mut string: String = String::new();
-                let mut remainder = divide_to_writeable(&mut string, i.0, i.1, PRECISION, false).unwrap();
+                let remainder = divide_to_writeable(&mut string, i.0, i.1, PRECISION, false).unwrap();
 
                 assert_eq!(string, i.2);
                 assert_eq!(remainder.is_zero(), i.3);

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,7 +53,7 @@ pub enum DivisionError {
 
     /// Errors external to the division algorithm still may be passed
     /// through the co-routines wrapped up with this constructor
-    ExternalError(Box<Error + Send + Sync>)
+    ExternalError(Box<dyn Error + Send + Sync>)
 }
 
 unsafe impl Sync for DivisionError {}

--- a/src/fraction/display.rs
+++ b/src/fraction/display.rs
@@ -189,7 +189,7 @@ impl Format {
     }
 }
 
-pub fn format_sign(sign: Sign, buffer: &mut fmt::Write, format: &Format) -> fmt::Result {
+pub fn format_sign(sign: Sign, buffer: &mut dyn fmt::Write, format: &Format) -> fmt::Result {
     if format.sign_plus() || (!format.sign_minus() && sign.is_negative()) {
         if format.sign_aware_zero_pad() {
             let format = format.clone().set_sign_aware_zero_pad(false);
@@ -222,7 +222,7 @@ pub fn format_sign(sign: Sign, buffer: &mut fmt::Write, format: &Format) -> fmt:
 
 pub fn format_fraction<T>(
     fraction: &GenericFraction<T>,
-    buffer: &mut fmt::Write,
+    buffer: &mut dyn fmt::Write,
     format: &Format,
 ) -> fmt::Result
 where
@@ -340,7 +340,7 @@ where
 }
 
 fn format_value<L, V>(
-    buffer: &mut fmt::Write,
+    buffer: &mut dyn fmt::Write,
     format: &Format,
     sign: Option<Sign>,
     value_length: L,
@@ -348,7 +348,7 @@ fn format_value<L, V>(
 ) -> fmt::Result
 where
     L: Fn(&Format) -> usize,
-    V: FnOnce(&mut fmt::Write, &Format) -> Result<usize, fmt::Error>,
+    V: FnOnce(&mut dyn fmt::Write, &Format) -> Result<usize, fmt::Error>,
 {
     if let Some(width) = format.width() {
         let width = *width;


### PR DESCRIPTION
Implicit dyn Traits are deprecated.

I simply ran `cargo fix` and tested with `cargo test --all`