### PR TITLE
Summing iterator implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraction"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["dnsl48 <dnsl48@gmail.com>"]
 
 description = "Lossless fractions and decimals; drop-in float replacement"

--- a/src/fraction/mod.rs
+++ b/src/fraction/mod.rs
@@ -2,6 +2,7 @@
 use super::{BigInt, BigUint};
 
 use error::ParseError;
+use std::iter::{Sum, Product};
 
 use super::{
     /*Float, */ Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Integer, Num, One,
@@ -1700,6 +1701,30 @@ where
                 }
             },
         };
+    }
+}
+
+impl<T: Clone + Integer> Sum for GenericFraction<T> {
+    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+        iter.fold(GenericFraction::<T>::zero(), Add::add)
+    }
+}
+
+impl<'a, T: 'a + Clone + Integer> Sum<&'a GenericFraction<T>> for GenericFraction<T> {
+    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+        iter.fold(GenericFraction::<T>::zero(), |ref s, x| Add::add(s, x))
+    }
+}
+
+impl<T: Clone + Integer> Product for GenericFraction<T> {
+    fn product<I: Iterator<Item=Self>>(iter: I) -> Self {
+        iter.fold(GenericFraction::<T>::one(), Mul::mul)
+    }
+}
+
+impl<'a, T: 'a + Clone + Integer> Product<&'a GenericFraction<T>> for GenericFraction<T> {
+    fn product<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+        iter.fold(GenericFraction::<T>::one(), |ref s, x| Mul::mul(s, x))
     }
 }
 
@@ -4346,5 +4371,19 @@ mod tests {
         );
 
         assert_eq!(1f64, Frac::one().to_f64().unwrap());
+    }
+
+    #[test]
+    fn summing_iterator() {
+        let values = vec![Fraction::new(2u64, 3u64), Fraction::new(1u64, 3u64)];
+        let sum: Fraction = values.iter().sum();
+        assert_eq!(sum, Fraction::new(1u8, 1u8));
+    }
+
+    #[test]
+    fn product_iterator() {
+        let values = vec![Fraction::new(2u64, 3u64), Fraction::new(1u64, 3u64)];
+        let product: Fraction = values.iter().product();
+        assert_eq!(product, Fraction::new(2u8, 9u8));
     }
 }


### PR DESCRIPTION
This issue aims to close #22 and to fix eutampieri/cardgamesbot#3
It implements the `std::iter::Sum` trait on iterators over `Fraction`s and `Decimal`s in order to easily sum large quantities of these.