### PR TITLE
Some code simplifications

### DIFF
--- a/src/decimal/mod.rs
+++ b/src/decimal/mod.rs
@@ -712,7 +712,7 @@ where
 
     fn from_str_radix(value: &str, base: u32) -> Result<Self, error::ParseError> {
         if base != 10 {
-            Err(error::ParseError::UnsupportedBase)?;
+            return Err(error::ParseError::UnsupportedBase);
         }
 
         Ok(GenericDecimal(

--- a/src/division.rs
+++ b/src/division.rs
@@ -20,10 +20,7 @@ pub struct DivisionState<I> {
 
 impl<I> DivisionState<I> {
     pub fn new(remainder: I, divisor: I) -> Self {
-        DivisionState {
-            remainder: remainder,
-            divisor: divisor,
-        }
+        DivisionState { remainder, divisor }
     }
 }
 
@@ -596,7 +593,7 @@ where
             keep_going = false;
             result
         }
-        result @ _ => result,
+        result => result,
     })?;
 
     if !keep_going {
@@ -625,7 +622,7 @@ where
                                     keep_going = false;
                                     result
                                 }
-                                result @ _ => result,
+                                result => result,
                             }?;
 
                             if !keep_going {
@@ -641,7 +638,7 @@ where
                                     keep_going = false;
                                     result
                                 }
-                                result @ _ => result,
+                                result => result,
                             }?;
 
                             if !keep_going {
@@ -654,7 +651,7 @@ where
                                 keep_going = false;
                                 result
                             }
-                            result @ _ => result,
+                            result => result,
                         }?;
 
                         if !keep_going {
@@ -678,7 +675,7 @@ where
                         keep_going = false;
                         result
                     }
-                    result @ _ => result,
+                    result => result,
                 }?;
 
                 if !keep_going {
@@ -694,7 +691,7 @@ where
                         keep_going = false;
                         result
                     }
-                    result @ _ => result,
+                    result => result,
                 }?;
 
                 if !keep_going {
@@ -710,7 +707,7 @@ where
                         keep_going = false;
                         result
                     }
-                    result @ _ => result,
+                    result => result,
                 }?;
 
                 if !keep_going {

--- a/src/dynaint.rs
+++ b/src/dynaint.rs
@@ -155,14 +155,6 @@ where
     G: Clone + GenericInteger + 'static,
 {
     #[inline]
-    fn _0() -> Self {
-        DynaInt::S(T::_0())
-    }
-    #[inline]
-    fn _1() -> Self {
-        DynaInt::S(T::_1())
-    }
-    #[inline]
     fn _10() -> Self {
         DynaInt::S(T::_10())
     }
@@ -948,8 +940,8 @@ mod tests {
 
     #[test]
     fn generic_integer() {
-        assert_eq!(0u8, D::_0().unpack().ok().unwrap());
-        assert_eq!(1u8, D::_1().unpack().ok().unwrap());
+        assert_eq!(0u8, D::zero().unpack().ok().unwrap());
+        assert_eq!(1u8, D::one().unpack().ok().unwrap());
         assert_eq!(10u8, D::_10().unpack().ok().unwrap());
 
         assert!(D::_0r().is_none());

--- a/src/dynaint.rs
+++ b/src/dynaint.rs
@@ -861,8 +861,8 @@ where
 
     fn from_str_radix(s: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
         T::from_str_radix(s, radix)
-            .and_then(|v| Ok(DynaInt::S(v)))
-            .or_else(|_| G::from_str_radix(s, radix).and_then(|v| Ok(DynaInt::h(v))))
+            .map(DynaInt::S)
+            .or_else(|_| G::from_str_radix(s, radix).map(DynaInt::h))
     }
 }
 

--- a/src/fraction/display.rs
+++ b/src/fraction/display.rs
@@ -76,17 +76,7 @@ impl Format {
             align: formatter.align(),
             width: formatter.width(),
             precision: formatter.precision(),
-            flags: flags,
-        }
-    }
-
-    pub fn clone(&self) -> Self {
-        Format {
-            fill: self.fill(),
-            align: self.cloned_align(),
-            width: self.width().clone(),
-            precision: self.precision().clone(),
-            flags: self.flags,
+            flags,
         }
     }
 
@@ -186,6 +176,18 @@ impl Format {
         }
 
         self
+    }
+}
+
+impl Clone for Format {
+    fn clone(&self) -> Self {
+        Format {
+            fill: self.fill(),
+            align: self.cloned_align(),
+            width: *self.width(),
+            precision: *self.precision(),
+            flags: self.flags,
+        }
     }
 }
 

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -72,12 +72,12 @@ pub trait GenericInteger:
 
 #[cfg(feature = "with-bigint")]
 lazy_static! {
-    static ref _0_BU: BigUint =  BigUint::zero() ;
-    static ref _1_BU: BigUint =  BigUint::one() ;
-    static ref _10_BU: BigUint =  BigUint::from(10u8) ;
-    static ref _0_BI: BigInt =  BigInt::zero() ;
-    static ref _1_BI: BigInt =  BigInt::one() ;
-    static ref _10_BI: BigInt =  BigInt::from(10i8) ;
+    static ref _0_BU: BigUint = BigUint::zero();
+    static ref _1_BU: BigUint = BigUint::one();
+    static ref _10_BU: BigUint = BigUint::from(10u8);
+    static ref _0_BI: BigInt = BigInt::zero();
+    static ref _1_BI: BigInt = BigInt::one();
+    static ref _10_BI: BigInt = BigInt::from(10i8);
 }
 
 #[cfg(feature = "with-bigint")]


### PR DESCRIPTION
Many of these are just Clippy suggestions.

1. Unify some `if` blocks.
2. Make `Format` a `Clone`able type by moving its `clone` method as a trait.
3. Use `map` instead of `and_then` in mapping `Result`s.
4. Clean up pattern matching.
5. `GenericInteger` trait now requires that `T` implements `Zero` and `One` from
`num_traits`. Thus removing the need to implement these 2 traits.

Also, I consider using names like `_*` a code smell...