### PR TITLE
Use a GCD initialization for f32 and f64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fraction"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["dnsl48 <dnsl48@gmail.com>"]
 
 description = "Lossless fractions and decimals; drop-in float replacement"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,10 @@ with-dynaint = []
 with-juniper-support = ["juniper"]
 with-postgres-support = ["postgres", "byteorder"]
 with-serde-support = ["serde", "serde_derive", "num/serde"]
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "bench_fraction"
+harness = false

--- a/benches/bench_fraction.rs
+++ b/benches/bench_fraction.rs
@@ -1,0 +1,22 @@
+extern crate criterion;
+extern crate fraction;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use fraction::GenericDecimal;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("Decimal u128/u16 init", |b| {
+        b.iter(|| {
+            GenericDecimal::<u128, u16>::from(black_box(15978.649));
+        })
+    });
+
+    c.bench_function("Decimal i64/u16 init", |b| {
+        b.iter(|| {
+            GenericDecimal::<i64, u16>::from(black_box(15978.649));
+            GenericDecimal::<i64, u16>::from(black_box(-15978.649));
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/decimal/mod.rs
+++ b/src/decimal/mod.rs
@@ -285,14 +285,17 @@ macro_rules! dec_impl {
     (impl_trait_from_float; $($t:ty),*) => {$(
         impl<T, P> From<$t> for GenericDecimal<T, P>
         where
-            T: Copy + Clone + GenericInteger + FromPrimitive,
-            P: Copy + GenericInteger + Into<usize> + From<u8>
+            T: Clone + GenericInteger + FromPrimitive,
+            P: Copy + GenericInteger + Into<usize> + From<u8> + Bounded
         {
             fn from(value: $t) -> Self {
                 if value.is_nan () { return GenericDecimal::nan() };
                 if value.is_infinite () { return if value.is_sign_negative () { GenericDecimal::neg_infinity() } else { GenericDecimal::infinity() } };
 
-                GenericDecimal(GenericFraction::from(value), P::zero())
+                let two = P::one() + P::one();
+                let hun = P::_10() * P::_10();
+                let max_precision = two * hun + hun / two + P::_10() / two; // 255
+                GenericDecimal(GenericFraction::from(value), P::zero()).calc_precision(Some(max_precision))
             }
         }
     )*}

--- a/src/decimal/mod.rs
+++ b/src/decimal/mod.rs
@@ -3,7 +3,7 @@ use error;
 
 use num::integer::Integer;
 use num::traits::{
-    /*Float, */ Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Num, One, Signed,
+    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Num, One, Signed,
     ToPrimitive, Zero,
 };
 
@@ -285,17 +285,14 @@ macro_rules! dec_impl {
     (impl_trait_from_float; $($t:ty),*) => {$(
         impl<T, P> From<$t> for GenericDecimal<T, P>
         where
-            T: Clone + GenericInteger,
+            T: Copy + Clone + GenericInteger + FromPrimitive,
             P: Copy + GenericInteger + Into<usize> + From<u8>
         {
             fn from(value: $t) -> Self {
                 if value.is_nan () { return GenericDecimal::nan() };
                 if value.is_infinite () { return if value.is_sign_negative () { GenericDecimal::neg_infinity() } else { GenericDecimal::infinity() } };
 
-                /* TODO: without the String conversion (probably through .to_bits) */
-                let src = format! ("{:+}", value);
-
-                GenericDecimal::from_decimal_str(&src).unwrap_or_else(|_| GenericDecimal::nan())
+                GenericDecimal(GenericFraction::from(value), P::zero())
             }
         }
     )*}

--- a/src/decimal/mod.rs
+++ b/src/decimal/mod.rs
@@ -97,7 +97,7 @@ where
         match *self {
             GenericDecimal(ref fraction, precision) => {
                 let prec = precision.into();
-                let debug_prec = f.precision().unwrap_or_else(|| 32);
+                let debug_prec = f.precision().unwrap_or(32);
                 write!(
                     f,
                     "GenericDecimal({} | prec={}; {:?}; {})",
@@ -845,7 +845,7 @@ where
                     GenericFraction::Infinity(_) => P::zero(),
                     GenericFraction::Rational(_, ref ratio) => {
                         let mut precision: P = P::zero();
-                        let max_precision: P = max_precision.unwrap_or_else(|| P::max_value());
+                        let max_precision: P = max_precision.unwrap_or(P::max_value());
 
                         let num = ratio.numer();
                         let den = ratio.denom();

--- a/src/decimal/mod.rs
+++ b/src/decimal/mod.rs
@@ -292,10 +292,7 @@ macro_rules! dec_impl {
                 if value.is_nan () { return GenericDecimal::nan() };
                 if value.is_infinite () { return if value.is_sign_negative () { GenericDecimal::neg_infinity() } else { GenericDecimal::infinity() } };
 
-                let two = P::one() + P::one();
-                let hun = P::_10() * P::_10();
-                let max_precision = two * hun + hun / two + P::_10() / two; // 255
-                GenericDecimal(GenericFraction::from(value), P::zero()).calc_precision(Some(max_precision))
+                GenericDecimal(GenericFraction::from(value), P::zero()).calc_precision(None)
             }
         }
     )*}

--- a/src/division.rs
+++ b/src/division.rs
@@ -20,10 +20,7 @@ pub struct DivisionState<I> {
 
 impl<I> DivisionState<I> {
     pub fn new(remainder: I, divisor: I) -> Self {
-        DivisionState {
-            remainder: remainder,
-            divisor: divisor,
-        }
+        DivisionState { remainder, divisor }
     }
 }
 

--- a/src/dynaint.rs
+++ b/src/dynaint.rs
@@ -861,8 +861,8 @@ where
 
     fn from_str_radix(s: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
         T::from_str_radix(s, radix)
-            .map(|v| DynaInt::S(v))
-            .or_else(|_| G::from_str_radix(s, radix).map(|v| DynaInt::h(v)))
+            .map(DynaInt::S)
+            .or_else(|_| G::from_str_radix(s, radix).map(DynaInt::h))
     }
 }
 

--- a/src/fraction/display.rs
+++ b/src/fraction/display.rs
@@ -76,7 +76,7 @@ impl Format {
             align: formatter.align(),
             width: formatter.width(),
             precision: formatter.precision(),
-            flags: flags,
+            flags,
         }
     }
 

--- a/src/fraction/mod.rs
+++ b/src/fraction/mod.rs
@@ -1,11 +1,10 @@
-#[cfg(feature = "with-bigint")]
 use super::{BigInt, BigUint};
-
+#[cfg(feature = "with-bigint")]
 use error::ParseError;
 use std::iter::{Product, Sum};
 
 use super::{
-    /*Float, */ Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Integer, Num, One,
+    gcd, Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Integer, Num, One,
     ParseRatioError, Ratio, Signed, ToPrimitive, Zero,
 };
 
@@ -519,7 +518,102 @@ where
 
         Ok(GenericFraction::Rational(sign, Ratio::new(num, den)))
     }
+
+    /// Parse a decimal f64 into a fraction and return the result.
+    /// Returns ParseError::OverflowError if there's not enough space in T to represent the decimal (use BigFraction in such a case)
+    /// Returns ParseError::ParseIntError if the string contains incorrect junk data (e.g. non-numeric characters).
+    /// May return ParseIntError if there is not enough volume in T to read whole part of the number into it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fraction::Fraction;
+    ///
+    /// let f = Fraction::from_decimal_f64(1.5_f64);
+    /// assert_eq! (f, Ok (Fraction::new(3u8, 2u8)));
+    /// ```
+    pub fn from_decimal_f64(src: f64) -> Result<Self, ParseError>
+    where
+        T: Copy + Clone + From<i32> + Integer + CheckedAdd + CheckedMul + CheckedSub,
+    {
+        let sign = if src < 0.0 { Sign::Minus } else { Sign::Plus };
+
+        // Using https://math.stackexchange.com/a/1049723/17452
+        // Find the max precision of this number
+        // Note: all computations happen in i32 until the end.
+        let mut p: i32 = 1;
+        let mut new_src = src;
+        loop {
+            if (new_src.round() - new_src).abs() < std::f64::EPSILON {
+                // Yay, we've found the precision of this number
+                break;
+            }
+            // Multiply by the precision
+            new_src *= 10_f64.powi(p);
+            p += 1;
+        }
+
+        // let ten: i32 = 10;
+        // for _ in 0..10 {
+        //     ten = ten + ten;
+        // }
+
+        // Compute the GCD
+        let src_u = new_src as i32;
+        let denom = 10_i32.pow(p as u32);
+
+        let g = gcd(src_u, denom);
+        let num = src_u / g;
+        let den = denom / g;
+
+        Ok(GenericFraction::Rational(
+            sign,
+            Ratio::new(num.into(), den.into()),
+        ))
+    }
 }
+
+// macro_rules! impl_trait_from_float {
+//     ($u:ty, $f:ty) => {
+//         impl From<$f> for GenericFraction<$u> {
+//             fn from(src: $f) -> Self {
+//                 let sign = if src < 0.0 { Sign::Minus } else { Sign::Plus };
+
+//                 // Using https://math.stackexchange.com/a/1049723/17452
+//                 // Find the max precision of this number
+//                 let mut p: $u = 0;
+//                 let mut new_src = src;
+//                 loop {
+//                     if (new_src.round() - new_src).abs() < 2e-16 {
+//                         // Yay, we've found the precision of this number
+//                         break;
+//                     }
+//                     // Multiply by the precision
+//                     // let p_u: u32 = p.into();
+//                     new_src *= 10_f64.powi(p as i32);
+//                     p = p + 1;
+//                 }
+
+//                 let ten: $u = 10;
+//                 // for _ in 0..10 {
+//                 //     ten = ten + ten;
+//                 // }
+
+//                 // Compute the GCD
+//                 let src_u = new_src as $u;
+//                 let denom: $u = ten.pow(p as u32);
+
+//                 let g = gcd(src_u, denom);
+//                 let num = src_u / g;
+//                 let den = p / g;
+
+//                 GenericFraction::Rational(sign, Ratio::new(num, den))
+//             }
+//         }
+//     };
+// }
+
+// impl_trait_from_float!(u128, f64);
 
 impl<T: Bounded + Clone + Integer> Bounded for GenericFraction<T> {
     fn min_value() -> Self {
@@ -2337,15 +2431,38 @@ fraction_from_generic_int!(u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usi
 macro_rules! generic_fraction_from_float {
     ( $($from:ty),*) => {
         $(
-        impl<T: Clone + Integer + CheckedAdd + CheckedMul + CheckedSub> From<$from> for GenericFraction<T> {
+        impl<T: Copy + Clone + FromPrimitive + Integer + CheckedAdd + CheckedMul + CheckedSub> From<$from> for GenericFraction<T> {
             fn from (val: $from) -> GenericFraction<T> {
                 if val.is_nan () { return GenericFraction::NaN };
                 if val.is_infinite () { return GenericFraction::Infinity (if val.is_sign_negative () { Sign::Minus } else { Sign::Plus }) };
 
-                /* TODO: without the String conversion (probably through .to_bits) */
-                let src = format! ("{:+}", val);
+                let sign = if val < 0.0 { Sign::Minus } else { Sign::Plus };
 
-                Self::from_decimal_str(&src).unwrap_or(GenericFraction::nan())
+                // Using https://math.stackexchange.com/a/1049723/17452
+                // Find the max precision of this number
+                // Note: all computations happen in i32 until the end.
+                let mut p: i32 = 0;
+                let mut new_val = val;
+                let ten: $from = 10.0;
+                loop {
+                    if (new_val.round() - new_val).abs() < <$from>::EPSILON {
+                        // Yay, we've found the precision of this number
+                        break;
+                    }
+                    // Multiply by the precision
+                    p += 1;
+                    new_val *= ten.powi(p);
+                }
+
+                // Compute the GCD
+                let src_u: T = T::from_f64(new_val.into()).unwrap();
+                let denom: T = T::from_i32(10_i32.pow(p as u32)).unwrap();
+
+                let g = gcd(src_u, denom);
+                let num = src_u / g;
+                let den = denom / g;
+
+                GenericFraction::Rational(sign, Ratio::new(num, den))
             }
         }
         )*

--- a/src/fraction/mod.rs
+++ b/src/fraction/mod.rs
@@ -3275,14 +3275,14 @@ mod tests {
             Frac::new_neg(2, 1)
         );
         assert_eq!(
-            Frac::new_neg(1, 1) + Frac::new_neg(1, 1),
+            &Frac::new_neg(1, 1) + &Frac::new_neg(1, 1),
             Frac::new_neg(2, 1)
         );
 
         assert_eq!(Frac::new_neg(1, 1) - Frac::new_neg(1, 1), Frac::zero());
         assert_eq!(Frac::new_neg(1, 1) - Frac::new_neg(2, 1), Frac::one());
-        assert_eq!(Frac::new_neg(1, 1) - Frac::new_neg(1, 1), Frac::zero());
-        assert_eq!(Frac::new_neg(1, 1) - Frac::new_neg(2, 1), Frac::one());
+        assert_eq!(&Frac::new_neg(1, 1) - &Frac::new_neg(1, 1), Frac::zero());
+        assert_eq!(&Frac::new_neg(1, 1) - &Frac::new_neg(2, 1), Frac::one());
 
         assert_eq!(Frac::new(1, 255), Frac::min_positive_value());
 

--- a/src/fraction/mod.rs
+++ b/src/fraction/mod.rs
@@ -2350,13 +2350,15 @@ macro_rules! generic_fraction_from_float {
                 let mut new_val = val;
                 let ten: $from = 10.0;
                 loop {
-                    if (new_val.round() - new_val).abs() < <$from>::EPSILON {
+                    if (new_val.floor() - new_val).abs() < <$from>::EPSILON {
                         // Yay, we've found the precision of this number
                         break;
                     }
                     // Multiply by the precision
+                    // Note: we multiply by powers of ten to avoid this kind of round error with f32s:
+                    // https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=b760579f103b7192c20413ebbe167b90
                     p += 1;
-                    new_val *= ten.powi(p);
+                    new_val = val * ten.powi(p);
                 }
 
                 // Compute the GCD
@@ -2696,12 +2698,13 @@ mod tests {
 
     #[test]
     fn from_f32() {
-        let f = Fraction::from(0f32);
-        assert_eq!(Sign::Plus, f.sign().unwrap());
-        assert_eq!(0, *f.numer().unwrap());
-        assert_eq!(1, *f.denom().unwrap());
+        // let f = Fraction::from(0f32);
+        // assert_eq!(Sign::Plus, f.sign().unwrap());
+        // assert_eq!(0, *f.numer().unwrap());
+        // assert_eq!(1, *f.denom().unwrap());
 
         let f = Fraction::from(0.01f32);
+        println!("{}", f);
         assert_eq!(Sign::Plus, f.sign().unwrap());
         assert_eq!(1, *f.numer().unwrap());
         assert_eq!(100, *f.denom().unwrap());

--- a/src/fraction/mod.rs
+++ b/src/fraction/mod.rs
@@ -1,5 +1,5 @@
-use super::{BigInt, BigUint};
 #[cfg(feature = "with-bigint")]
+use super::{BigInt, BigUint};
 use error::ParseError;
 use std::iter::{Product, Sum};
 
@@ -2338,8 +2338,8 @@ macro_rules! generic_fraction_from_float {
         $(
         impl<T: Copy + Clone + FromPrimitive + Integer + CheckedAdd + CheckedMul + CheckedSub> From<$from> for GenericFraction<T> {
             fn from(val: $from) -> GenericFraction<T> {
-                if val.is_nan () { return GenericFraction::NaN };
-                if val.is_infinite () { return GenericFraction::Infinity (if val.is_sign_negative () { Sign::Minus } else { Sign::Plus }) };
+                if val.is_nan () { return Self::NaN };
+                if val.is_infinite () { return Self::Infinity (if val.is_sign_negative () { Sign::Minus } else { Sign::Plus }) };
 
                 let sign = if val < 0.0 { Sign::Minus } else { Sign::Plus };
 
@@ -2367,7 +2367,7 @@ macro_rules! generic_fraction_from_float {
                     None => {
                         // Could not convert, let's revert to the string method
                         let src = format! ("{:+}", val);
-                        return Self::from_decimal_str(&src).unwrap_or(GenericFraction::nan());
+                        return Self::from_decimal_str(&src).unwrap_or(Self::nan());
                     }
                 };
                 let denom: T = match T::from_f64(ten.powi(p).into()) {
@@ -2375,7 +2375,7 @@ macro_rules! generic_fraction_from_float {
                     None => {
                         // Could not convert, let's revert to the string method
                         let src = format! ("{:+}", val);
-                        return Self::from_decimal_str(&src).unwrap_or(GenericFraction::nan());
+                        return Self::from_decimal_str(&src).unwrap_or(Self::nan());
                     }
                 };
 
@@ -2383,7 +2383,7 @@ macro_rules! generic_fraction_from_float {
                 let num = src_u / g;
                 let den = denom / g;
 
-                GenericFraction::Rational(sign, Ratio::new(num, den))
+                Self::Rational(sign, Ratio::new(num, den))
             }
         }
         )*
@@ -2698,13 +2698,12 @@ mod tests {
 
     #[test]
     fn from_f32() {
-        // let f = Fraction::from(0f32);
-        // assert_eq!(Sign::Plus, f.sign().unwrap());
-        // assert_eq!(0, *f.numer().unwrap());
-        // assert_eq!(1, *f.denom().unwrap());
+        let f = Fraction::from(0f32);
+        assert_eq!(Sign::Plus, f.sign().unwrap());
+        assert_eq!(0, *f.numer().unwrap());
+        assert_eq!(1, *f.denom().unwrap());
 
         let f = Fraction::from(0.01f32);
-        println!("{}", f);
         assert_eq!(Sign::Plus, f.sign().unwrap());
         assert_eq!(1, *f.numer().unwrap());
         assert_eq!(100, *f.denom().unwrap());

--- a/src/fraction/mod.rs
+++ b/src/fraction/mod.rs
@@ -2456,7 +2456,7 @@ macro_rules! generic_fraction_from_float {
 
                 // Compute the GCD
                 let src_u: T = T::from_f64(new_val.into()).unwrap();
-                let denom: T = T::from_i32(10_i32.pow(p as u32)).unwrap();
+                let denom: T = T::from_f64(ten.powi(p).into()).unwrap();
 
                 let g = gcd(src_u, denom);
                 let num = src_u / g;

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -72,12 +72,12 @@ pub trait GenericInteger:
 
 #[cfg(feature = "with-bigint")]
 lazy_static! {
-    static ref _0_BU: BigUint =  BigUint::zero() ;
-    static ref _1_BU: BigUint =  BigUint::one() ;
-    static ref _10_BU: BigUint =  BigUint::from(10u8) ;
-    static ref _0_BI: BigInt =  BigInt::zero() ;
-    static ref _1_BI: BigInt =  BigInt::one() ;
-    static ref _10_BI: BigInt =  BigInt::from(10i8) ;
+    static ref _0_BU: BigUint = BigUint::zero();
+    static ref _1_BU: BigUint = BigUint::one();
+    static ref _10_BU: BigUint = BigUint::from(10u8);
+    static ref _0_BI: BigInt = BigInt::zero();
+    static ref _1_BI: BigInt = BigInt::one();
+    static ref _10_BI: BigInt = BigInt::from(10i8);
 }
 
 #[cfg(feature = "with-bigint")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,6 @@ pub use num::bigint::{BigInt, BigUint};
 
 pub use num::rational::{ParseRatioError, Ratio};
 
-pub use num::integer::gcd;
-
 pub use num::{
     Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Integer, Num, One,
     Signed, ToPrimitive, Zero,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,10 +101,11 @@ pub use num::bigint::{BigInt, BigUint};
 
 pub use num::rational::{ParseRatioError, Ratio};
 
+pub use num::integer::gcd;
+
 pub use num::{
-    /*#[cfg(feature="std")] Float,*/
-    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Integer, Num, One, Signed, ToPrimitive,
-    Zero,
+    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Integer, Num, One,
+    Signed, ToPrimitive, Zero,
 };
 
 #[cfg(test)]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1906,11 +1906,15 @@ macro_rules! generate_ops_tests {
 
 #[test]
 fn fraction_from_float() {
-    macro_rules! test_for_t {
+    macro_rules! test_for_smaller_t {
         ( $($t:ty),*) => {
             $(
+                let f = GenericFraction::<$t>::from(2.0);
+                assert_eq!(format!("{}", f), "2");
                 let f = GenericFraction::<$t>::from(0.5);
                 assert_eq!(format!("{}", f), "1/2");
+                let f = GenericFraction::<$t>::from(15978.649);
+                assert_eq!(format!("{}", f), "NaN");
             )*
         };
     };
@@ -1918,11 +1922,15 @@ fn fraction_from_float() {
     macro_rules! test_for_larger_t {
         ( $($t:ty),*) => {
             $(
+                let f = GenericFraction::<$t>::from(2.0);
+                assert_eq!(format!("{}", f), "2");
+                let f = GenericFraction::<$t>::from(0.5);
+                assert_eq!(format!("{}", f), "1/2");
                 let f = GenericFraction::<$t>::from(15978.649);
                 assert_eq!(format!("{}", f), "15978649/1000");
             )*
         };
     };
-    test_for_t!(u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, isize);
+    test_for_smaller_t!(u8, i8, u16, i16);
     test_for_larger_t!(u32, i32, u64, i64, u128, i128, usize, isize);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1914,5 +1914,15 @@ fn fraction_from_float() {
             )*
         };
     };
+
+    macro_rules! test_for_larger_t {
+        ( $($t:ty),*) => {
+            $(
+                let f = GenericFraction::<$t>::from(15978.649);
+                assert_eq!(format!("{}", f), "15978649/1000");
+            )*
+        };
+    };
     test_for_t!(u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, isize);
+    test_for_larger_t!(u32, i32, u64, i64, u128, i128, usize, isize);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,5 @@
+use super::fraction::GenericFraction;
+
 macro_rules! generate_ops_tests {
     (
         Zero => $_0:block;
@@ -1900,4 +1902,19 @@ macro_rules! generate_ops_tests {
             assert_eq!(thr_, one);
         }
     };
+}
+
+#[test]
+fn fraction_from_float() {
+    macro_rules! test_for_t {
+        ( $($t:ty),*) => {
+            $(
+                let expect = GenericFraction::<$t>::new(1, 2);
+                let f = GenericFraction::<$t>::from(0.5);
+                assert_eq!(f, expect);
+            )*
+        };
+    };
+    // test_for_t!(u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, isize);
+    test_for_t!(u8, i8, i32, i64);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1934,3 +1934,15 @@ fn fraction_from_float() {
     test_for_smaller_t!(u8, i8, u16, i16);
     test_for_larger_t!(u32, i32, u64, i64, u128, i128, usize, isize);
 }
+
+#[test]
+#[cfg(feature = "with-bigint")]
+fn bigfraction_from_float() {
+    use super::BigFraction;
+    let f = BigFraction::from(2.0);
+    assert_eq!(format!("{}", f), "2");
+    let f = BigFraction::from(0.5);
+    assert_eq!(format!("{}", f), "1/2");
+    let f = BigFraction::from(15978.649);
+    assert_eq!(format!("{}", f), "15978649/1000");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1909,12 +1909,10 @@ fn fraction_from_float() {
     macro_rules! test_for_t {
         ( $($t:ty),*) => {
             $(
-                let expect = GenericFraction::<$t>::new(1, 2);
                 let f = GenericFraction::<$t>::from(0.5);
-                assert_eq!(f, expect);
+                assert_eq!(format!("{}", f), "1/2");
             )*
         };
     };
-    // test_for_t!(u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, isize);
-    test_for_t!(u8, i8, i32, i64);
+    test_for_t!(u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, isize);
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,3 @@
-use super::fraction::GenericFraction;
-
 macro_rules! generate_ops_tests {
     (
         Zero => $_0:block;
@@ -1902,47 +1900,4 @@ macro_rules! generate_ops_tests {
             assert_eq!(thr_, one);
         }
     };
-}
-
-#[test]
-fn fraction_from_float() {
-    macro_rules! test_for_smaller_t {
-        ( $($t:ty),*) => {
-            $(
-                let f = GenericFraction::<$t>::from(2.0);
-                assert_eq!(format!("{}", f), "2");
-                let f = GenericFraction::<$t>::from(0.5);
-                assert_eq!(format!("{}", f), "1/2");
-                let f = GenericFraction::<$t>::from(15978.649);
-                assert_eq!(format!("{}", f), "NaN");
-            )*
-        };
-    };
-
-    macro_rules! test_for_larger_t {
-        ( $($t:ty),*) => {
-            $(
-                let f = GenericFraction::<$t>::from(2.0);
-                assert_eq!(format!("{}", f), "2");
-                let f = GenericFraction::<$t>::from(0.5);
-                assert_eq!(format!("{}", f), "1/2");
-                let f = GenericFraction::<$t>::from(15978.649);
-                assert_eq!(format!("{}", f), "15978649/1000");
-            )*
-        };
-    };
-    test_for_smaller_t!(u8, i8, u16, i16);
-    test_for_larger_t!(u32, i32, u64, i64, u128, i128, usize, isize);
-}
-
-#[test]
-#[cfg(feature = "with-bigint")]
-fn bigfraction_from_float() {
-    use super::BigFraction;
-    let f = BigFraction::from(2.0);
-    assert_eq!(format!("{}", f), "2");
-    let f = BigFraction::from(0.5);
-    assert_eq!(format!("{}", f), "1/2");
-    let f = BigFraction::from(15978.649);
-    assert_eq!(format!("{}", f), "15978649/1000");
 }


### PR DESCRIPTION
Implements #36 

Current bugs (help wanted):
- [x] In src/decimal/mod.rs line 295, the Decimal is initialized as `GenericDecimal(GenericFraction::from(value), P::zero())`. What should be the correct precision? This causes the test `decimal::tests::hash_and_partial_eq` to fail.
- [x] Possibly related to the bug above, `thread 'fraction::display::tests::display' panicked at 'internal error: entered unreachable code', src/division.rs:353:21`. 