### PR TITLE
added Ord trait to GenericFraction

### DIFF
--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -518,18 +518,17 @@ impl<T: Clone + Integer> PartialOrd for GenericFraction<T> {
 
 impl<T: Clone + Integer> Ord for GenericFraction<T> {
      fn cmp(&self, other: &Self) -> Ordering {
-         match self {
-             GenericFraction::NaN => {
-                 match other {
-                     GenericFraction::NaN => Ordering::Equal,
-                     _ => Ordering::Less,
-		 }
-             },
-             _ => {
-                 match other {
-                     GenericFraction::NaN => Ordering::Greater,
-                     _ => self.partial_cmp(other).unwrap(),
-                 }
+         if *self == GenericFraction::NaN {
+             if *other == GenericFraction::NaN {
+                 Ordering::Equal
+             } else {
+                 Ordering::Less
+             }
+         } else {
+             if *other == GenericFraction::NaN {
+                 Ordering::Greater
+             } else {
+                 self.partial_cmp(other).unwrap()        
              }
          }
      }

--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -528,7 +528,7 @@ impl<T: Clone + Integer> Ord for GenericFraction<T> {
              if *other == GenericFraction::NaN {
                  Ordering::Greater
              } else {
-                 self.partial_cmp(other).unwrap()        
+                 self.partial_cmp(other).expect("Well when I wrote this the only way partial_cmp() would return None was if one of the argument was NaN, which they weren't in this case.")        
              }
          }
      }

--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -516,6 +516,26 @@ impl<T: Clone + Integer> PartialOrd for GenericFraction<T> {
     }
 }
 
+impl<T: Clone + Integer> Ord for GenericFraction<T> {
+     fn cmp(&self, other: &Self) -> Ordering {
+         match self {
+             GenericFraction::NaN => {
+                 match other {
+                     GenericFraction::NaN => Ordering::Equal,
+                     _ => Ordering::Less,
+		 }
+             },
+             _ => {
+                 match other {
+                     GenericFraction::NaN => Ordering::Greater,
+                     _ => self.partial_cmp(other).unwrap(),
+                 }
+             }
+         }
+     }
+}
+
+
 impl<T: Clone + Integer> Neg for GenericFraction<T> {
     type Output = GenericFraction<T>;
 


### PR DESCRIPTION
I made it so the NaN is less than everything else.

I needed this, so I can use fractions as the key to a BTreeMap.