### PR TITLE
Just realized that Implementations of PartialOrd, and Ord must agree with each other

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: dnsl48

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ with-serde-support = ["serde", "serde_derive", "num/serde"]
 
 [dev-dependencies]
 criterion = "0.4"
+rand = "0.8.5"
 
 [[bench]]
 name = "bench_fraction"

--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -518,18 +518,17 @@ impl<T: Clone + Integer> PartialOrd for GenericFraction<T> {
 
 impl<T: Clone + Integer> Ord for GenericFraction<T> {
      fn cmp(&self, other: &Self) -> Ordering {
-         match self {
-             GenericFraction::NaN => {
-                 match other {
-                     GenericFraction::NaN => Ordering::Equal,
-                     _ => Ordering::Less,
-		 }
-             },
-             _ => {
-                 match other {
-                     GenericFraction::NaN => Ordering::Greater,
-                     _ => self.partial_cmp(other).unwrap(),
-                 }
+         if *self == GenericFraction::NaN {
+             if *other == GenericFraction::NaN {
+                 Ordering::Equal
+             } else {
+                 Ordering::Less
+             }
+         } else {
+             if *other == GenericFraction::NaN {
+                 Ordering::Greater
+             } else {
+                 self.partial_cmp(other).unwrap()        
              }
          }
      }

--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -2560,13 +2560,13 @@ mod tests {
         for _ in 0..10 {
             let base_value: i8 = rng.gen();
             let min = GenericFraction::<i64>::from(base_value);
-    
+
             let bump: u8 = rng.gen();
             let bump: i32 = base_value as i32 + bump as i32;
             let max = GenericFraction::<i64>::from(bump);
-    
+
             let test_value = GenericFraction::<i64>::new(rng.gen::<u8>(), rng.gen::<u8>());
-    
+
             clamp_agree_with_cmp(&min, &max, &test_value);
         }
     }
@@ -2581,22 +2581,24 @@ mod tests {
         }
 
         let clamped = test_value.clamp(min, max);
-    
+
         match (test_value.cmp(min), test_value.cmp(max)) {
             (Ordering::Less, Ordering::Less) => assert_eq!(clamped, min),
             (Ordering::Less, Ordering::Equal) => assert_eq!(clamped, min),
-            (Ordering::Less, Ordering::Greater) => panic!("Shouldn't be possible to be less than min and greater than max"),
-    
+            (Ordering::Less, Ordering::Greater) => {
+                panic!("Shouldn't be possible to be less than min and greater than max")
+            }
+
             (Ordering::Equal, Ordering::Less) => assert_eq!(clamped, min),
             (Ordering::Equal, Ordering::Equal) => {
                 assert_eq!(clamped, min);
                 assert_eq!(clamped, max);
             }
             (Ordering::Equal, Ordering::Greater) => assert_eq!(clamped, max),
-    
+
             (Ordering::Greater, Ordering::Less) => assert_eq!(clamped, test_value),
             (Ordering::Greater, Ordering::Equal) => assert_eq!(clamped, max),
             (Ordering::Greater, Ordering::Greater) => assert_eq!(clamped, max),
         }
-    }    
+    }
 }

--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -528,7 +528,7 @@ impl<T: Clone + Integer> Ord for GenericFraction<T> {
              if *other == GenericFraction::NaN {
                  Ordering::Greater
              } else {
-                 self.partial_cmp(other).unwrap()        
+                 self.partial_cmp(other).expect("Well when I wrote this the only way partial_cmp() would return None was if one of the argument was NaN, which they weren't in this case.")        
              }
          }
      }

--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -517,21 +517,19 @@ impl<T: Clone + Integer> PartialOrd for GenericFraction<T> {
 }
 
 impl<T: Clone + Integer> Ord for GenericFraction<T> {
-     fn cmp(&self, other: &Self) -> Ordering {
-         if *self == GenericFraction::NaN {
-             if *other == GenericFraction::NaN {
-                 Ordering::Equal
-             } else {
-                 Ordering::Less
-             }
-         } else {
-             if *other == GenericFraction::NaN {
-                 Ordering::Greater
-             } else {
-                 self.partial_cmp(other).expect("Well when I wrote this the only way partial_cmp() would return None was if one of the argument was NaN, which they weren't in this case.")        
-             }
-         }
-     }
+    fn cmp(&self, other: &Self) -> Ordering {
+        if *self == GenericFraction::NaN {
+            if *other == GenericFraction::NaN {
+               Ordering::Equal
+            } else {
+                Ordering::Less
+            }
+        } else if *other == GenericFraction::NaN {
+            Ordering::Greater
+        } else {
+            self.partial_cmp(other).expect("Well when I wrote this the only way partial_cmp() would return None was if one of the argument was NaN, which they weren't in this case.")        
+        }
+    }
 }
 
 

--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -516,6 +516,26 @@ impl<T: Clone + Integer> PartialOrd for GenericFraction<T> {
     }
 }
 
+impl<T: Clone + Integer> Ord for GenericFraction<T> {
+     fn cmp(&self, other: &Self) -> Ordering {
+         match self {
+             GenericFraction::NaN => {
+                 match other {
+                     GenericFraction::NaN => Ordering::Equal,
+                     _ => Ordering::Less,
+		 }
+             },
+             _ => {
+                 match other {
+                     GenericFraction::NaN => Ordering::Greater,
+                     _ => self.partial_cmp(other).unwrap(),
+                 }
+             }
+         }
+     }
+}
+
+
 impl<T: Clone + Integer> Neg for GenericFraction<T> {
     type Output = GenericFraction<T>;
 

--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -2554,22 +2554,6 @@ mod tests {
             assert_eq!(fra.denom(), Some(&BigUint::from(1u8)));
         }
     }
-    #[test]
-    fn foobar() {
-        let mut rng = rand::thread_rng();
-        for _ in 0..10 {
-            let base_value: i8 = rng.gen();
-            let min = GenericFraction::<i64>::from(base_value);
-
-            let bump: u8 = rng.gen();
-            let bump: i32 = base_value as i32 + bump as i32;
-            let max = GenericFraction::<i64>::from(bump);
-
-            let test_value = GenericFraction::<i64>::new(rng.gen::<u8>(), rng.gen::<u8>());
-
-            clamp_agree_with_cmp(&min, &max, &test_value);
-        }
-    }
 
     fn clamp_agree_with_cmp<T: Clone + Integer + std::fmt::Debug + GenericInteger>(
         min: &GenericFraction<T>,
@@ -2599,6 +2583,95 @@ mod tests {
             (Ordering::Greater, Ordering::Less) => assert_eq!(clamped, test_value),
             (Ordering::Greater, Ordering::Equal) => assert_eq!(clamped, max),
             (Ordering::Greater, Ordering::Greater) => assert_eq!(clamped, max),
+        }
+    }
+    #[test]
+    fn rational_rational_rational_clamp_cmp_agreement_test() {
+        let mut rng = rand::thread_rng();
+        for _ in 0..10 {
+            let base_value: i8 = rng.gen();
+            let min = GenericFraction::<i64>::from(base_value);
+
+            let bump: u8 = rng.gen();
+            let bump: i32 = base_value as i32 + bump as i32;
+            let max = GenericFraction::<i64>::from(bump);
+
+            let test_value = GenericFraction::<i64>::new(rng.gen::<u8>(), rng.gen::<u8>());
+
+            clamp_agree_with_cmp(&min, &max, &test_value);
+        }
+    }
+    #[test]
+    fn rational_nan_rational_clamp_cmp_agreement_test() {
+        let mut rng = rand::thread_rng();
+        for _ in 0..10 {
+            let base_value: i8 = rng.gen();
+            let min = GenericFraction::<i64>::from(base_value);
+
+            let bump: u8 = rng.gen();
+            let bump: i32 = base_value as i32 + bump as i32;
+            let max = GenericFraction::<i64>::from(bump);
+
+            let nan = GenericFraction::<i64>::NaN;
+
+            clamp_agree_with_cmp(&min, &max, &nan);
+        }
+    }
+    #[test]
+    fn nan_pos_infinity_partail_cmp_cmp_agreement_test() {
+        let nan = GenericFraction::<i64>::NaN;
+        let pos_inf = GenericFraction::<i64>::infinity();
+
+        assert_eq!(nan.partial_cmp(&pos_inf), Some(nan.cmp(&pos_inf)));
+    }
+    #[test]
+    fn nan_neg_infinity_partail_cmp_cmp_agreement_test() {
+        let nan = GenericFraction::<i64>::NaN;
+        let neg_inf = GenericFraction::<i64>::neg_infinity();
+
+        assert_eq!(nan.partial_cmp(&neg_inf), Some(nan.cmp(&neg_inf)));
+    }
+    #[test]
+    fn nan_rational_partail_cmp_cmp_agreement_test() {
+        let mut rng = rand::thread_rng();
+
+        let nan = GenericFraction::<i64>::NaN;
+
+        for _ in 0..10 {
+            let base_value: i8 = rng.gen();
+            let test_value = GenericFraction::<i64>::from(base_value);
+
+            assert_eq!(nan.partial_cmp(&test_value), Some(nan.cmp(&test_value)));
+        }
+    }
+    #[test]
+    fn pos_inf_rational_partail_cmp_cmp_agreement_test() {
+        let mut rng = rand::thread_rng();
+
+        let pos_inf = GenericFraction::<i64>::infinity();
+        for _ in 0..10 {
+            let base_value: i8 = rng.gen();
+            let test_value = GenericFraction::<i64>::from(base_value);
+
+            assert_eq!(
+                pos_inf.partial_cmp(&test_value),
+                Some(pos_inf.cmp(&test_value))
+            );
+        }
+    }
+    #[test]
+    fn neg_inf_rational_partail_cmp_cmp_agreement_test() {
+        let mut rng = rand::thread_rng();
+
+        let neg_inf = GenericFraction::<i64>::neg_infinity();
+        for _ in 0..10 {
+            let base_value: i8 = rng.gen();
+            let test_value = GenericFraction::<i64>::from(base_value);
+
+            assert_eq!(
+                neg_inf.partial_cmp(&test_value),
+                Some(neg_inf.cmp(&test_value))
+            );
         }
     }
 }


### PR DESCRIPTION
Older version of the docs just said

> Implementations of PartialEq, PartialOrd, and Ord _must_ agree with each other. It's easy to accidentally make them disagree by deriving some of the traits and manually implementing others.

The latest says, 

>Implementations must be consistent with the [PartialOrd](https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html) implementation, and ensure max, min, and clamp are consistent with cmp:
>
> *   partial_cmp(a, b) == Some(cmp(a, b)).
> *   max(a, b) == max_by(a, b, cmp) (ensured by the default implementation).
> *   min(a, b) == min_by(a, b, cmp) (ensured by the default implementation).
> *  For a.clamp(min, max), see the [method docs](https://doc.rust-lang.org/std/cmp/trait.Ord.html#method.clamp) (ensured by the default implementation).

So I cut and pasted partail_cmp to cmp and removed the Some()s and rewrote it so that it doesn't use nested match statements while I was adding the checks for NaN