### PR TITLE
Clippy / allow manual filtering in GenericFraction::to_i64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.13.1] - ????-??-??
+### Added
+ - Clippy hint to allow manual filtering in GenericFraction::to_i64 implementation
+
 ## [0.13.0] - 2023-01-01
 
 ### Changed

--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -682,6 +682,7 @@ impl<T: Clone + Integer + PartialEq + ToPrimitive> ToPrimitive for GenericFracti
         match *self {
             GenericFraction::NaN => None,
             GenericFraction::Infinity(_) => None,
+            #[allow(clippy::manual_filter)]
             GenericFraction::Rational(sign, ref r) if *r.denom() == T::one() => {
                 if let Some(n) = r.numer().to_i64() {
                     if sign == Sign::Minus {


### PR DESCRIPTION
Removes the suboptimal clippy warning introduced in its recent versions.