### PR TITLE
Fixed floor, ceil and round for negative GenericFractions

### DIFF
--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -930,10 +930,17 @@ impl<T: Clone + Integer> GenericFraction<T> {
     /// type F = GenericFraction<u8>;
     ///
     /// assert_eq! (F::new (7u8, 5u8).ceil (), F::new (10u8, 5u8));
+    /// assert_eq! (F::new_neg (4u8, 3u8).ceil (), F::new_neg (1u8, 1u8));
     /// ```
     pub fn ceil(&self) -> Self {
         match *self {
-            GenericFraction::Rational(s, ref r) => GenericFraction::Rational(s, r.ceil()),
+            GenericFraction::Rational(Sign::Plus, ref r) => {
+                GenericFraction::Rational(Sign::Plus, r.ceil())
+            }
+            GenericFraction::Rational(Sign::Minus, ref r) => {
+                // Floor of the unsigned ratio results in a ceil for the signed fraction
+                GenericFraction::Rational(Sign::Minus, r.floor())
+            }
             _ => self.clone(),
         }
     }

--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -945,7 +945,7 @@ impl<T: Clone + Integer> GenericFraction<T> {
         }
     }
 
-    /// Returns the nearest integer to the value (.5 goes up)
+    /// Returns the nearest integer to the value (.5 goes away from zero)
     ///
     /// # Examples
     ///
@@ -957,6 +957,7 @@ impl<T: Clone + Integer> GenericFraction<T> {
     /// assert_eq! (F::new (8u8, 5u8).round (), F::new (10u8, 5u8));
     /// assert_eq! (F::new (3u8, 2u8).round (), F::new (4u8, 2u8));
     /// assert_eq! (F::new (1u8, 2u8).round (), F::new (2u8, 2u8));
+    /// assert_eq! (F::new_neg (3u8, 2u8).round (), F::new_neg (2u8, 1u8));
     /// ```
     pub fn round(&self) -> Self {
         match *self {

--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -906,10 +906,17 @@ impl<T: Clone + Integer> GenericFraction<T> {
     /// type F = GenericFraction<u8>;
     ///
     /// assert_eq! (F::new (7u8, 5u8).floor (), F::new (5u8, 5u8));
+    /// assert_eq! (F::new_neg (4u8, 3u8).floor (), F::new_neg (2u8, 1u8));
     /// ```
     pub fn floor(&self) -> Self {
         match *self {
-            GenericFraction::Rational(s, ref r) => GenericFraction::Rational(s, r.floor()),
+            GenericFraction::Rational(Sign::Plus, ref r) => {
+                GenericFraction::Rational(Sign::Plus, r.floor())
+            }
+            GenericFraction::Rational(Sign::Minus, ref r) => {
+                // Ceil of the unsigned ratio results in a floor for the signed fraction
+                GenericFraction::Rational(Sign::Minus, r.ceil())
+            }
             _ => self.clone(),
         }
     }


### PR DESCRIPTION
Fixes the problem where `floor`, `ceil` functions round negative `GenericFractions` the wrong way.
Also fixed docs for `round` to accuratly describe its behaviour with rounding negative half-way cases, and be consistent with how floats are rounded.
fixes #81 