### PR TITLE
added alternate forms of '/' and set default Display to '⁄': FRACTION SLASH

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ with-juniper-support = ["juniper"]
 with-postgres-support = ["postgres-types", "byteorder", "bytes"]
 with-serde-support = ["serde", "serde_derive", "num/serde"]
 
+with-unicode = []
+
 [dev-dependencies]
 criterion = "0.4"
 rand = "0.8.5"

--- a/src/fraction/mod.rs
+++ b/src/fraction/mod.rs
@@ -5,7 +5,9 @@ pub use self::sign::Sign;
 pub mod approx;
 
 pub mod display;
-mod unicode_fromto_str;
+
+#[cfg(feature = "with-unicode")]
+mod unicode_str_io;
 
 #[cfg(feature = "with-juniper-support")]
 pub mod juniper_support;

--- a/src/fraction/mod.rs
+++ b/src/fraction/mod.rs
@@ -5,6 +5,7 @@ pub use self::sign::Sign;
 pub mod approx;
 
 pub mod display;
+pub mod unicode_fromto_str;
 
 #[cfg(feature = "with-juniper-support")]
 pub mod juniper_support;

--- a/src/fraction/mod.rs
+++ b/src/fraction/mod.rs
@@ -7,7 +7,7 @@ pub mod approx;
 pub mod display;
 
 #[cfg(feature = "with-unicode")]
-mod unicode_str_io;
+pub mod unicode_str_io;
 
 #[cfg(feature = "with-juniper-support")]
 pub mod juniper_support;

--- a/src/fraction/mod.rs
+++ b/src/fraction/mod.rs
@@ -5,7 +5,7 @@ pub use self::sign::Sign;
 pub mod approx;
 
 pub mod display;
-pub mod unicode_fromto_str;
+mod unicode_fromto_str;
 
 #[cfg(feature = "with-juniper-support")]
 pub mod juniper_support;

--- a/src/fraction/unicode_fromto_str.rs
+++ b/src/fraction/unicode_fromto_str.rs
@@ -8,6 +8,19 @@ use std::{fmt, str};
 use Integer;
 
 impl<T: Clone + Integer + Display + From<u8>> GenericFraction<T> {
+    /// Display the fraction using FRACTION SLASH '\u{2044}' '⁄'
+    /// If you have font support, this is the way Unicode wants to display fractions
+    /// ```
+    /// use fraction::Fraction;
+    /// assert_eq!(
+    ///   format!("{}", Fraction::new(1u8,2u8).display_unicode()),
+    ///   "1⁄2"
+    /// );
+    /// assert_eq!(
+    ///   format!("{}", Fraction::new(3u8,2u8).display_unicode()),
+    ///   "3⁄2"
+    /// );
+    /// ```
     pub fn display_unicode(&self) -> impl fmt::Display + '_ {
         struct UnicodeDisplay<'a, T: Clone + Integer>(&'a GenericFraction<T>);
         impl<'a, T> fmt::Display for UnicodeDisplay<'a, T>
@@ -33,6 +46,20 @@ impl<T: Clone + Integer + Display + From<u8>> GenericFraction<T> {
         UnicodeDisplay(self)
     }
 
+    /// Display the fraction using FRACTION SLASH '\u{2044}' '⁄' as a mixed fraction e.g. "1⁤1⁄2"
+    /// Will put INVISIBLE PLUS '\u{2064}' as a separator '⁤'
+    /// If you have font support, this is the way Unicode wants to display fractions
+    /// ```
+    /// use fraction::Fraction;
+    /// assert_eq!(
+    ///   format!("{}", Fraction::new(1u8,2u8).display_unicode_mixed()),
+    ///   "1⁄2"
+    /// );
+    /// assert_eq!(
+    ///   format!("{}", Fraction::new(3u8,2u8).display_unicode_mixed()),
+    ///   "1⁤1⁄2"
+    /// );
+    /// ```
     pub fn display_unicode_mixed(&self) -> impl Display + '_ {
         struct S<'a, T: Clone + Integer + fmt::Display>(&'a GenericFraction<T>);
         impl<'a, T> fmt::Display for S<'a, T>
@@ -58,6 +85,19 @@ impl<T: Clone + Integer + Display + From<u8>> GenericFraction<T> {
         S(self)
     }
 
+    /// Display the fraction using super/subscript
+    /// This will look OK without font support
+    /// ```
+    /// use fraction::Fraction;
+    /// assert_eq!(
+    ///   format!("{}", Fraction::new(1u8,2u8).display_supsub()),
+    ///   "¹/₂"
+    /// );
+    /// assert_eq!(
+    ///   format!("{}", Fraction::new(3u8,2u8).display_supsub()),
+    ///   "³/₂"
+    /// );
+    /// ```
     pub fn display_supsub(&self) -> impl Display + '_ {
         struct S<'a, T: Clone + Integer + fmt::Display>(&'a GenericFraction<T>);
         impl<'a, T> fmt::Display for S<'a, T>
@@ -71,32 +111,40 @@ impl<T: Clone + Integer + Display + From<u8>> GenericFraction<T> {
                             f,
                             "{}{}/{}",
                             s,
-                            r.numer().to_string().chars().map(|c| match c {
-                                '1' => '¹',
-                                '2' => '²',
-                                '3' => '³',
-                                '4' => '⁴',
-                                '5' => '⁵',
-                                '6' => '⁶',
-                                '7' => '⁷',
-                                '8' => '⁸',
-                                '9' => '⁹',
-                                '0' => '⁰',
-                                _ => '?',
-                            }).collect::<String>(),
-                            r.denom().to_string().chars().map(|c| match c {
-                                '1' => '₁',
-                                '2' => '₂',
-                                '3' => '₃',
-                                '4' => '₄',
-                                '5' => '₅',
-                                '6' => '₆',
-                                '7' => '₇',
-                                '8' => '₈',
-                                '9' => '₉',
-                                '0' => '₀',
-                            c => c,
-                            }).collect::<String>(),
+                            r.numer()
+                                .to_string()
+                                .chars()
+                                .map(|c| match c {
+                                    '1' => '¹',
+                                    '2' => '²',
+                                    '3' => '³',
+                                    '4' => '⁴',
+                                    '5' => '⁵',
+                                    '6' => '⁶',
+                                    '7' => '⁷',
+                                    '8' => '⁸',
+                                    '9' => '⁹',
+                                    '0' => '⁰',
+                                    _ => '?',
+                                })
+                                .collect::<String>(),
+                            r.denom()
+                                .to_string()
+                                .chars()
+                                .map(|c| match c {
+                                    '1' => '₁',
+                                    '2' => '₂',
+                                    '3' => '₃',
+                                    '4' => '₄',
+                                    '5' => '₅',
+                                    '6' => '₆',
+                                    '7' => '₇',
+                                    '8' => '₈',
+                                    '9' => '₉',
+                                    '0' => '₀',
+                                    c => c,
+                                })
+                                .collect::<String>(),
                         )
                     }
                     _ => write!(f, "{}", self.0.display_unicode()),
@@ -106,6 +154,19 @@ impl<T: Clone + Integer + Display + From<u8>> GenericFraction<T> {
         S(self)
     }
 
+    /// Display the fraction as a mixed fraction using super/subscript e.g. "1¹/₂"
+    /// This will look OK without font support
+    /// ```
+    /// use fraction::Fraction;
+    /// assert_eq!(
+    ///   format!("{}", Fraction::new(1u8,2u8).display_supsub_mixed()),
+    ///   "¹/₂"
+    /// );
+    /// assert_eq!(
+    ///   format!("{}", Fraction::new(3u8,2u8).display_supsub_mixed()),
+    ///   "1¹/₂"
+    /// );
+    /// ```
     pub fn display_supsub_mixed(&self) -> impl Display + '_ {
         struct S<'a, T: Clone + Integer + fmt::Display>(&'a GenericFraction<T>);
         impl<'a, T> fmt::Display for S<'a, T>
@@ -115,7 +176,14 @@ impl<T: Clone + Integer + Display + From<u8>> GenericFraction<T> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match &self.0 {
                     GenericFraction::Rational(s, r) if r.fract() != *r && !r.denom().is_one() => {
-                        write!(f, "{}{}{}", s, r.trunc().numer(), GenericFraction::Rational(Sign::Plus, r.fract().clone()).display_supsub())
+                        write!(
+                            f,
+                            "{}{}{}",
+                            s,
+                            r.trunc().numer(),
+                            GenericFraction::Rational(Sign::Plus, r.fract().clone())
+                                .display_supsub()
+                        )
                     }
                     _ => write!(f, "{}", self.0.display_supsub()),
                 }
@@ -124,7 +192,46 @@ impl<T: Clone + Integer + Display + From<u8>> GenericFraction<T> {
         S(self)
     }
 
-    pub fn unicode_parse(input: &str) -> Result<Self, ParseError> {
+    /// Parse a unicode string
+    /// The string can be:
+    /// - A normal fraction e.g. "1/2"
+    /// - A vulgar fraction e.g. "½"
+    /// - ~A mixed vulgar fraction "1½"~
+    /// - A unicode fraction e.g. "1⁄2" where '⁄' can be any of:
+    ///   - '/' ASCII SOLIDUS
+    ///   - '⁄' FRACTION SLASH
+    ///   - '∕' DIVISION SLASH
+    ///   - '÷' DIVISION SIGN
+    /// - A mixed unicode fraction: "1\u{2063}1⁄2": 1⁤1⁄2
+    ///   - '\u{2064}' INVISIBLE PLUS
+    ///   - '\u{2063}' INVISIBLE SEPARATOR
+    ///   - NOT ~'\u{2062}' INVISIBLE TIMES~
+    /// - A super-subscript fraction "¹/₂"
+    /// - A mixed super-subscript fraction  "1¹/₂"
+    ///
+    /// Focus is on being lenient towards input rather than being fast.
+    /// ```
+    /// use fraction::Fraction;
+    /// let v = vec![
+    ///  ("1/2", Fraction::new(1u8,2u8)),
+    ///  ("-1/2", Fraction::new_neg(1u8,2u8)),
+    ///  ("½", Fraction::new(1u8,2u8)),
+    ///  // ("1½", Fraction::new(1u8,2u8)),
+    ///  // ("-1½", Fraction::new_neg(1u8,2u8)),
+    ///  ("1⁄2", Fraction::new(1u8,2u8)),
+    ///  ("-1⁄2", Fraction::new_neg(1u8,2u8)),
+    ///  ("1⁤1⁄2", Fraction::new(3u8,2u8)),
+    ///  ("-1⁤1⁄2", Fraction::new_neg(3u8,2u8)),
+    ///  ("¹/₂", Fraction::new(1u8,2u8)),
+    ///  ("-¹/₂", Fraction::new_neg(1u8,2u8)),
+    ///  ("1¹/₂", Fraction::new(3u8,2u8)),
+    ///  ("-1¹/₂", Fraction::new_neg(3u8,2u8)),
+    /// ];
+    /// for (f_str, f) in v {
+    ///   assert_eq!(Fraction::parse_unicode(f_str), Ok(f))
+    /// }
+    /// ```
+    pub fn parse_unicode(input: &str) -> Result<Self, ParseError> {
         let s: &str;
         let sign = if input.starts_with('-') {
             s = &input[1..];
@@ -202,8 +309,6 @@ impl<T: Clone + Integer + Display + From<u8>> GenericFraction<T> {
                 Ratio::new_raw(4.into(), 5.into()),
             ))
         } else if let Some((first, denom_str)) = s.split_once(&['/', '⁄', '∕', '÷'][..]) {
-            let mut numer: T;
-            let denom: T;
             // allow for mixed fractions of the shape 1²/₃
             if let Some(idx) =
                 first.find(&['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹', '⁰'][..])
@@ -218,7 +323,7 @@ impl<T: Clone + Integer + Display + From<u8>> GenericFraction<T> {
                     t
                 };
 
-                let Ok(n) = T::from_str_radix(
+                let Ok(numer) = T::from_str_radix(
                     &first[idx..]
                         .chars()
                         .map(|c| match c {
@@ -239,10 +344,10 @@ impl<T: Clone + Integer + Display + From<u8>> GenericFraction<T> {
                 ) else {
                     return Err(ParseError::ParseIntError);
                 };
-                numer = n;
+                // numer = n;
                 println!("numer: {}", &numer);
-                let Ok(d) = T::from_str_radix(
-                    // let n = 
+                let Ok(denom) = T::from_str_radix(
+                    // let n =
                     &denom_str
                         .chars()
                         .map(|c| match c {
@@ -263,9 +368,13 @@ impl<T: Clone + Integer + Display + From<u8>> GenericFraction<T> {
                 ) else {
                     return Err(ParseError::ParseIntError);
                 };
-                println!("denom: {}", d);
-                denom = d;
-                numer = numer + trunc * denom.clone();
+                println!("denom: {}", denom);
+                // denom = d;
+                // numer = numer + trunc * denom.clone();
+                Ok(GenericFraction::Rational(
+                    sign,
+                    Ratio::new(numer + trunc * denom.clone(), denom),
+                ))
             } else
             // also allow for mixed fractions to be parsed: `1⁤1⁄2`
             // allowed invisible separators: \u{2064} \u{2063}
@@ -273,29 +382,30 @@ impl<T: Clone + Integer + Display + From<u8>> GenericFraction<T> {
             if let Some((trunc_str, numer_str)) =
                 first.split_once(&['\u{2064}', '\u{2063}'][..])
             {
-                let Ok(n) = T::from_str_radix(numer_str, 10) else {
+                let Ok(numer) = T::from_str_radix(numer_str, 10) else {
                     return Err(ParseError::ParseIntError);
                 };
-                numer = n;
                 let Ok(trunc) = T::from_str_radix(trunc_str, 10) else {
                     return Err(ParseError::ParseIntError);
                 };
-                let Ok(d) = T::from_str_radix(denom_str, 10) else {
+                let Ok(denom) = T::from_str_radix(denom_str, 10) else {
                     return Err(ParseError::ParseIntError);
                 };
-                denom = d;
-                numer = numer + trunc * denom.clone();
+                Ok(GenericFraction::Rational(
+                    sign,
+                    Ratio::new(numer + trunc * denom.clone(), denom),
+                ))
             } else {
-                let Ok(n) = T::from_str_radix(&first, 10) else {
+                let Ok(numer) = T::from_str_radix(&first, 10) else {
                     return Err(ParseError::ParseIntError);
                 };
-                numer = n;
-                let Ok(d) = T::from_str_radix(denom_str, 10) else {
+
+                let Ok(denom) = T::from_str_radix(denom_str, 10) else {
                     return Err(ParseError::ParseIntError);
                 };
-                denom = d;
+
+                Ok(GenericFraction::Rational(sign, Ratio::new(numer, denom)))
             }
-            Ok(GenericFraction::Rational(sign, Ratio::new(numer, denom)))
         } else {
             let Ok(val) = T::from_str_radix(&s, 10) else {
                 return Err(ParseError::ParseIntError);
@@ -330,7 +440,7 @@ mod tests {
         ];
         for (string, frac) in test_vec {
             println!("{} ?= {}", string, frac);
-            assert_eq!(Fraction::unicode_parse(string), Ok(frac));
+            assert_eq!(Fraction::parse_unicode(string), Ok(frac));
             println!("{} ?= {}", string, frac);
             assert_eq!(format!("{}", frac.display_unicode()), string);
         }
@@ -386,7 +496,7 @@ mod tests {
         ];
         for (string, frac) in test_vec {
             println!("{} ?= {}", string, frac);
-            assert_eq!(Fraction::unicode_parse(string), Ok(frac));
+            assert_eq!(Fraction::parse_unicode(string), Ok(frac));
             // println!("{} ?= {}", string, frac);
             // assert_eq!(format!("{}", frac.display_unicode()), string);
         }
@@ -402,7 +512,7 @@ mod tests {
         ];
         for (string, frac) in test_vec {
             println!("{} ?= {}", string, frac);
-            assert_eq!(Fraction::unicode_parse(string), Ok(frac));
+            assert_eq!(Fraction::parse_unicode(string), Ok(frac));
             println!("{} ?= {}", string, frac);
             assert_eq!(format!("{}", frac.display_supsub()), string);
         }
@@ -417,7 +527,7 @@ mod tests {
         ];
         for (string, frac) in test_vec {
             println!("{} ?= {}", string, frac);
-            assert_eq!(Fraction::unicode_parse(string), Ok(frac));
+            assert_eq!(Fraction::parse_unicode(string), Ok(frac));
             println!("{} ?= {}", string, frac);
             assert_eq!(format!("{}", frac.display_supsub_mixed()), string);
         }
@@ -436,10 +546,12 @@ mod tests {
             ("1\u{2064}1⁄2", Fraction::new(3u8, 2u8)),
             // ("1⁣1⁄2", Fraction::new(3u8, 2u8)),
             ("-1\u{2064}1⁄2", Fraction::new_neg(3u8, 2u8)),
+            ("1⁄2", Fraction::new(1u8, 2u8)),
+            ("-1⁄2", Fraction::new_neg(1u8, 2u8)),
         ];
         for (string, frac) in test_vec {
             println!("{} ?= {}", string, frac);
-            let f_test = Fraction::unicode_parse(string);
+            let f_test = Fraction::parse_unicode(string);
             assert_eq!(f_test, Ok(frac));
             assert_eq!(format!("{}", frac.display_unicode_mixed()), string);
         }
@@ -461,7 +573,7 @@ mod tests {
         ];
         for s in test_vec {
             println!("{}", s);
-            assert_eq!(Fraction::unicode_parse(s), Err(ParseError::ParseIntError))
+            assert_eq!(Fraction::parse_unicode(s), Err(ParseError::ParseIntError))
         }
     }
 
@@ -469,7 +581,7 @@ mod tests {
     fn test_fromstr_fraction_ops() {
         let test_vec = vec!["1", "1/2", "3/2"];
         for s in test_vec {
-            let f = Fraction::unicode_parse(s).unwrap();
+            let f = Fraction::parse_unicode(s).unwrap();
             assert_eq!(f * Fraction::one(), f);
             assert_eq!(f + Fraction::zero(), f);
         }

--- a/src/fraction/unicode_fromto_str.rs
+++ b/src/fraction/unicode_fromto_str.rs
@@ -1,65 +1,84 @@
+use std::fmt::Display;
+
 use crate::fraction::GenericFraction;
-extern crate core;
-use self::core::{fmt, str};
+use std::{fmt, str};
 use crate::{error::ParseError, Sign};
 use num::rational::Ratio;
 use Integer;
 
-#[derive(Debug, PartialEq)]
-pub struct UnicodeFromToStr<T: Clone + Integer>(GenericFraction<T>);
-
-impl<T> fmt::Display for UnicodeFromToStr<T>
-where
-    T: Clone + Integer + fmt::Display,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.0 {
-            GenericFraction::NaN => write!(f, "NaN"),
-            GenericFraction::Infinity(s) => {
-                write!(f, "{}∞", s)
-            }
-            GenericFraction::Rational(s, r) => {
-                write!(f, "{}{}", s, r.numer())?;
-                if !r.denom().is_one() {
-                    write!(f, "⁄{}", r.denom())?;
+impl<T: Clone + Integer + Display> GenericFraction<T> {
+    pub fn unicode_display(&self) -> impl fmt::Display + '_ {
+        struct UnicodeDisplay<'a, T: Clone + Integer>(&'a GenericFraction<T>);
+        impl<'a, T> fmt::Display for UnicodeDisplay<'a, T>
+        where
+            T: Clone + Integer + fmt::Display,
+        {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match &self.0 {
+                    GenericFraction::NaN => write!(f, "NaN"),
+                    GenericFraction::Infinity(s) => {
+                        write!(f, "{}∞", s)
+                    }
+                    GenericFraction::Rational(s, r) => {
+                        write!(f, "{}{}", s, r.numer())?;
+                        if !r.denom().is_one() {
+                            write!(f, "⁄{}", r.denom())?;
+                        }
+                        Ok(())
+                    }
                 }
-                Ok(())
             }
         }
+        UnicodeDisplay(self)
     }
-}
 
-impl<T> str::FromStr for UnicodeFromToStr<T>
-where
-    T: Clone + Integer + fmt::Display,
-{
-    type Err = ParseError;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (sign, start) = if s.starts_with('-') {
-            (Sign::Minus, 1)
-        } else if s.starts_with('+') {
-            (Sign::Plus, 1)
-        } else {
-            (Sign::Plus, 0)
-        };
-        if s[start..].to_lowercase().starts_with("nan") {
-            Ok(Self(GenericFraction::nan()))
-        } else if s[start..].starts_with("∞")
-            || s[start..].starts_with("inf")
-            || s[start..].starts_with("infty")
+    pub fn unicode_display_mixed(&self) -> impl Display + '_ {
+        struct S<'a, T: Clone + Integer + fmt::Display>(&'a GenericFraction<T>);
+        impl<'a, T> fmt::Display for S<'a, T>
+        where
+            T: Clone + Integer + fmt::Display,
         {
-            Ok(Self(GenericFraction::Infinity(sign)))
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                match &self.0 {
+                    GenericFraction::Rational(s, r) if r.fract() != *r  && !r.denom().is_one() => {
+                        write!(f, "{}{}\u{2064}{}⁄{}", s, r.trunc().numer(), r.fract().numer(), r.fract().denom())
+                    }
+                    _ => write!(f, "{}", self.0.unicode_display())
+                }
+            }
+        }
+        S(self)
+    }
+
+    pub fn unicode_parse(input: &str) -> Result<Self, ParseError> {
+        let s: &str;
+        let sign = if input.starts_with('-') {
+            s = &input[1..];
+            Sign::Minus
+            
+        } else if input.starts_with('+') {
+            s = &input[1..];
+            Sign::Plus
+        } else {
+            s = input;
+            Sign::Plus
+        };
+        if s.to_lowercase().starts_with("nan") {
+            Ok(GenericFraction::nan())
+        } else if s.starts_with("∞")
+            || s.starts_with("inf")
+            || s.starts_with("infty")
+        {
+            Ok(GenericFraction::Infinity(sign))
         } else if let Some((first, denom_str)) = s.split_once(&['/', '⁄', '∕', '÷'][..]) {
-            // also allow for mixed fractions to be parsed: `1+1/2` or `1⁤1⁄2`
+            // also allow for mixed fractions to be parsed: `1⁤1⁄2`
             // allowed invisible separators: \u{2064} \u{2063}
             // '+' is disallowed, bc it would be confusing with -1+1/2
             let mut numer: T;
             let denom: T;
             if let Some((trunc_str, numer_str)) =
-                first[start..].split_once(&['\u{2064}', '\u{2063}'][..])
+                first.split_once(&['\u{2064}', '\u{2063}'][..])
             {
-                // let Ok(nu)
-                println!("mixed!");
                 let Ok(n) = T::from_str_radix(numer_str, 10) else {
                     return Err(ParseError::ParseIntError);
                 };
@@ -74,7 +93,7 @@ where
                 denom = d;
                 numer = numer + trunc * denom.clone();
             } else {
-                let Ok(n) = T::from_str_radix(&first[start..], 10) else {
+                let Ok(n) = T::from_str_radix(&first, 10) else {
                     return Err(ParseError::ParseIntError);
                 };
                 numer = n;
@@ -83,42 +102,29 @@ where
                 };
                 denom = d;
             }
-            Ok(Self(GenericFraction::Rational(
+            Ok(GenericFraction::Rational(
                 sign,
                 Ratio::new(numer, denom),
-            )))
+            ))
         } else {
-            let Ok(val) = T::from_str_radix(&s[start..], 10) else {
+            let Ok(val) = T::from_str_radix(&s, 10) else {
                 return Err(ParseError::ParseIntError);
             };
-            Ok(Self(GenericFraction::Rational(
+            Ok(GenericFraction::Rational(
                 sign,
                 Ratio::new(val, T::one()),
-            )))
+            ))
         }
-    }
-}
-
-impl<T: Clone + Integer> From<UnicodeFromToStr<T>> for GenericFraction<T> {
-    fn from(value: UnicodeFromToStr<T>) -> Self {
-        value.0
-    }
-}
-
-impl<T: Clone + Integer> From<GenericFraction<T>> for UnicodeFromToStr<T> {
-    fn from(value: GenericFraction<T>) -> Self {
-        Self(value)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{num::ParseIntError, str::FromStr};
 
     use num::{One, Zero};
 
     use crate::{
-        error::ParseError, unicode_fromto_str::UnicodeFromToStr, Fraction, GenericFraction,
+        error::ParseError, Fraction,
     };
 
     #[test]
@@ -138,28 +144,35 @@ mod tests {
         ];
         for (string, frac) in test_vec {
             println!("{} ?= {}", string, frac);
-            assert_eq!(UnicodeFromToStr::from_str(string).unwrap().0, frac);
+            assert_eq!(Fraction::unicode_parse(string), Ok(frac));
             println!("{} ?= {}", string, frac);
-            assert_eq!(format!("{}", UnicodeFromToStr(frac)), string);
+            assert_eq!(format!("{}", frac.unicode_display()), string);
         }
     }
 
     #[test]
-    fn test_from_str() {
+    fn test_fromto_str_mixed() {
         let test_vec = vec![
-            ("Nan", Fraction::nan()),
-            ("nan", Fraction::nan()),
-            ("+∞", Fraction::infinity()),
-            ("+1", Fraction::one()),
-            ("+5", Fraction::from(5)),
-            ("1⁤1⁄2", Fraction::new(3u8, 2u8)),
-            ("1⁣1⁄2", Fraction::new(3u8, 2u8)),
-            ("-1⁤1⁄2", Fraction::new_neg(3u8, 2u8)),
+            ("NaN", Fraction::nan()),
+            ("∞", Fraction::infinity()),
+            ("-∞", Fraction::neg_infinity()),
+            ("0", Fraction::zero()),
+            ("1", Fraction::one()),
+            ("-1", -Fraction::one()),
+            ("5", Fraction::from(5)),
+            // ("nan", Fraction::nan()),
+            // ("+∞", Fraction::infinity()),
+            // ("+1", Fraction::one()),
+            // ("+5", Fraction::from(5)),
+            ("1\u{2064}1⁄2", Fraction::new(3u8, 2u8)),
+            // ("1⁣1⁄2", Fraction::new(3u8, 2u8)),
+            ("-1\u{2064}1⁄2", Fraction::new_neg(3u8, 2u8)),
         ];
         for (string, frac) in test_vec {
             println!("{} ?= {}", string, frac);
-            let f_test = UnicodeFromToStr::from_str(string).unwrap().0;
-            assert_eq!(f_test, frac);
+            let f_test = Fraction::unicode_parse(string);
+            assert_eq!(f_test, Ok(frac));
+            assert_eq!(format!("{}", frac.unicode_display_mixed()), string);
         }
     }
 
@@ -175,13 +188,28 @@ mod tests {
             "1⁤1⁄2BOGUS",
             "1⁣1⁄2BOGUS",
             "-1⁤1⁄2BOGUS",
+            "1⁢1⁄2" // uses INVISIBLE_TIMES
         ];
         for s in test_vec {
             println!("{}", s);
             assert_eq!(
-                UnicodeFromToStr::<u64>::from_str(s).err(),
-                Some(ParseError::ParseIntError)
+                Fraction::unicode_parse(s),
+                Err(ParseError::ParseIntError)
             )
+        }
+    }
+
+    #[test]
+    fn test_fromstr_fraction_ops() {
+        let test_vec = vec![
+            "1",
+            "1/2",
+            "3/2",
+        ];
+        for s in test_vec {
+            let f = Fraction::unicode_parse(s).unwrap();
+            assert_eq!(f*Fraction::one(), f);
+            assert_eq!(f+Fraction::zero(), f);
         }
     }
 }

--- a/src/fraction/unicode_fromto_str.rs
+++ b/src/fraction/unicode_fromto_str.rs
@@ -1,0 +1,187 @@
+use crate::fraction::GenericFraction;
+extern crate core;
+use self::core::{fmt, str};
+use crate::{error::ParseError, Sign};
+use num::rational::Ratio;
+use Integer;
+
+#[derive(Debug, PartialEq)]
+pub struct UnicodeFromToStr<T: Clone + Integer>(GenericFraction<T>);
+
+impl<T> fmt::Display for UnicodeFromToStr<T>
+where
+    T: Clone + Integer + fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            GenericFraction::NaN => write!(f, "NaN"),
+            GenericFraction::Infinity(s) => {
+                write!(f, "{}∞", s)
+            }
+            GenericFraction::Rational(s, r) => {
+                write!(f, "{}{}", s, r.numer())?;
+                if !r.denom().is_one() {
+                    write!(f, "⁄{}", r.denom())?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl<T> str::FromStr for UnicodeFromToStr<T>
+where
+    T: Clone + Integer + fmt::Display,
+{
+    type Err = ParseError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (sign, start) = if s.starts_with('-') {
+            (Sign::Minus, 1)
+        } else if s.starts_with('+') {
+            (Sign::Plus, 1)
+        } else {
+            (Sign::Plus, 0)
+        };
+        if s[start..].to_lowercase().starts_with("nan") {
+            Ok(Self(GenericFraction::nan()))
+        } else if s[start..].starts_with("∞")
+            || s[start..].starts_with("inf")
+            || s[start..].starts_with("infty")
+        {
+            Ok(Self(GenericFraction::Infinity(sign)))
+        } else if let Some((first, denom_str)) = s.split_once(&['/', '⁄', '∕', '÷'][..]) {
+            // also allow for mixed fractions to be parsed: `1+1/2` or `1⁤1⁄2`
+            // allowed invisible separators: \u{2064} \u{2063}
+            // '+' is disallowed, bc it would be confusing with -1+1/2
+            let mut numer: T;
+            let denom: T;
+            if let Some((trunc_str, numer_str)) =
+                first[start..].split_once(&['\u{2064}', '\u{2063}'][..])
+            {
+                // let Ok(nu)
+                println!("mixed!");
+                let Ok(n) = T::from_str_radix(numer_str, 10) else {
+                    return Err(ParseError::ParseIntError);
+                };
+                numer = n;
+                let Ok(t) = T::from_str_radix(trunc_str, 10) else {
+                    return Err(ParseError::ParseIntError);
+                };
+                let trunc = t;
+                let Ok(d) = T::from_str_radix(denom_str, 10) else {
+                    return Err(ParseError::ParseIntError);
+                };
+                denom = d;
+                numer = numer + trunc * denom.clone();
+            } else {
+                let Ok(n) = T::from_str_radix(&first[start..], 10) else {
+                    return Err(ParseError::ParseIntError);
+                };
+                numer = n;
+                let Ok(d) = T::from_str_radix(denom_str, 10) else {
+                    return Err(ParseError::ParseIntError);
+                };
+                denom = d;
+            }
+            Ok(Self(GenericFraction::Rational(
+                sign,
+                Ratio::new(numer, denom),
+            )))
+        } else {
+            let Ok(val) = T::from_str_radix(&s[start..], 10) else {
+                return Err(ParseError::ParseIntError);
+            };
+            Ok(Self(GenericFraction::Rational(
+                sign,
+                Ratio::new(val, T::one()),
+            )))
+        }
+    }
+}
+
+impl<T: Clone + Integer> From<UnicodeFromToStr<T>> for GenericFraction<T> {
+    fn from(value: UnicodeFromToStr<T>) -> Self {
+        value.0
+    }
+}
+
+impl<T: Clone + Integer> From<GenericFraction<T>> for UnicodeFromToStr<T> {
+    fn from(value: GenericFraction<T>) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{num::ParseIntError, str::FromStr};
+
+    use num::{One, Zero};
+
+    use crate::{
+        error::ParseError, unicode_fromto_str::UnicodeFromToStr, Fraction, GenericFraction,
+    };
+
+    #[test]
+    fn test_fromto_str() {
+        let test_vec = vec![
+            ("NaN", Fraction::nan()),
+            ("∞", Fraction::infinity()),
+            ("-∞", Fraction::neg_infinity()),
+            ("0", Fraction::zero()),
+            ("1", Fraction::one()),
+            ("-1", -Fraction::one()),
+            ("5", Fraction::from(5)),
+            ("1⁄2", Fraction::new(1u8, 2u8)),
+            ("-1⁄2", Fraction::new_neg(1u8, 2u8)),
+            ("3⁄2", Fraction::new(3u8, 2u8)),
+            ("-3⁄2", Fraction::new_neg(3u8, 2u8)),
+        ];
+        for (string, frac) in test_vec {
+            println!("{} ?= {}", string, frac);
+            assert_eq!(UnicodeFromToStr::from_str(string).unwrap().0, frac);
+            println!("{} ?= {}", string, frac);
+            assert_eq!(format!("{}", UnicodeFromToStr(frac)), string);
+        }
+    }
+
+    #[test]
+    fn test_from_str() {
+        let test_vec = vec![
+            ("Nan", Fraction::nan()),
+            ("nan", Fraction::nan()),
+            ("+∞", Fraction::infinity()),
+            ("+1", Fraction::one()),
+            ("+5", Fraction::from(5)),
+            ("1⁤1⁄2", Fraction::new(3u8, 2u8)),
+            ("1⁣1⁄2", Fraction::new(3u8, 2u8)),
+            ("-1⁤1⁄2", Fraction::new_neg(3u8, 2u8)),
+        ];
+        for (string, frac) in test_vec {
+            println!("{} ?= {}", string, frac);
+            let f_test = UnicodeFromToStr::from_str(string).unwrap().0;
+            assert_eq!(f_test, frac);
+        }
+    }
+
+    #[test]
+    fn test_from_fail() {
+        let test_vec = vec![
+            "asdf",
+            // "NanBOGUS",
+            // "nanBOGUS",
+            // "+∞BOGUS",
+            "+1BOGUS",
+            "+5BOGUS",
+            "1⁤1⁄2BOGUS",
+            "1⁣1⁄2BOGUS",
+            "-1⁤1⁄2BOGUS",
+        ];
+        for s in test_vec {
+            println!("{}", s);
+            assert_eq!(
+                UnicodeFromToStr::<u64>::from_str(s).err(),
+                Some(ParseError::ParseIntError)
+            )
+        }
+    }
+}

--- a/src/fraction/unicode_str_io.rs
+++ b/src/fraction/unicode_str_io.rs
@@ -190,7 +190,7 @@ impl<T: Clone + Integer + fmt::Display> GenericFraction<T> {
     }
 }
 
-impl<T: Clone + Integer + fmt::Display + From<u8>> GenericFraction<T> {
+impl<T: Clone + Integer + From<u8>> GenericFraction<T> {
     /// Parse a unicode string
     /// The string can be:
     /// - A normal fraction e.g. "1/2"
@@ -215,8 +215,8 @@ impl<T: Clone + Integer + fmt::Display + From<u8>> GenericFraction<T> {
     ///  ("1/2", Fraction::new(1u8,2u8)),
     ///  ("-1/2", Fraction::new_neg(1u8,2u8)),
     ///  ("½", Fraction::new(1u8,2u8)),
-    ///  // ("1½", Fraction::new(1u8,2u8)),
-    ///  // ("-1½", Fraction::new_neg(1u8,2u8)),
+    ///  // ("1½", Fraction::new(3u8,2u8)),       // mixed vulgar fractions
+    ///  // ("-1½", Fraction::new_neg(3u8,2u8)),  // currently not supported
     ///  ("1⁄2", Fraction::new(1u8,2u8)),
     ///  ("-1⁄2", Fraction::new_neg(1u8,2u8)),
     ///  ("1⁤1⁄2", Fraction::new(3u8,2u8)),
@@ -312,7 +312,6 @@ impl<T: Clone + Integer + fmt::Display + From<u8>> GenericFraction<T> {
             if let Some(idx) =
                 first.find(&['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹', '⁰'][..])
             {
-                println!("Supsub! {}", first);
                 let trunc = if idx.is_zero() {
                     T::zero()
                 } else {
@@ -343,8 +342,6 @@ impl<T: Clone + Integer + fmt::Display + From<u8>> GenericFraction<T> {
                 ) else {
                     return Err(ParseError::ParseIntError);
                 };
-                // numer = n;
-                println!("numer: {}", &numer);
                 let Ok(denom) = T::from_str_radix(
                     // let n =
                     &denom_str
@@ -367,9 +364,6 @@ impl<T: Clone + Integer + fmt::Display + From<u8>> GenericFraction<T> {
                 ) else {
                     return Err(ParseError::ParseIntError);
                 };
-                println!("denom: {}", denom);
-                // denom = d;
-                // numer = numer + trunc * denom.clone();
                 Ok(GenericFraction::Rational(
                     sign,
                     Ratio::new(numer + trunc * denom.clone(), denom),
@@ -494,8 +488,6 @@ mod tests {
         for (string, frac) in test_vec {
             println!("{} ?= {}", string, frac);
             assert_eq!(Fraction::from_unicode_str(string), Ok(frac));
-            // println!("{} ?= {}", string, frac);
-            // assert_eq!(format!("{}", frac.get_unicode_display()), string);
         }
     }
 
@@ -544,7 +536,6 @@ mod tests {
             ("-1", -Fraction::one()),
             ("5", Fraction::from(5)),
             ("1\u{2064}1⁄2", Fraction::new(3u8, 2u8)),
-            // ("1⁣1⁄2", Fraction::new(3u8, 2u8)),
             ("-1\u{2064}1⁄2", Fraction::new_neg(3u8, 2u8)),
             ("1⁄2", Fraction::new(1u8, 2u8)),
             ("-1⁄2", Fraction::new_neg(1u8, 2u8)),
@@ -559,11 +550,11 @@ mod tests {
 
     #[test]
     fn test_from_fail() {
+        // TODO: "nanBOGUS" and "∞BOGUS" will parse.
+        // Either make that everything with BOGUS 
+        // after will parse, or make ^those fail.
         let test_vec = vec![
             "asdf",
-            // "NanBOGUS",
-            // "nanBOGUS",
-            // "+∞BOGUS",
             "+1BOGUS",
             "+5BOGUS",
             "1⁤1⁄2BOGUS",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 //! - `with-bigint` (default) integration with [num::BigInt] and [num::BigUint] data types
 //! - `with-decimal` (default) [Decimal] type implemented upon [GenericFraction]
 //! - `with-dynaint` (default) dynamically growing integer avoiding stack overflows
+//! - `with-unicode` Unicode formatting and parsing options
 //! - `with-approx` adds methods for approximate computations (currently `sqrt`)
 //! - `with-juniper-support` [Juniper](https://crates.io/crates/juniper) integration
 //! - `with-postgres-support` [PostgreSQL](https://crates.io/crates/postgres) integration; Numeric/Decimal type
@@ -152,6 +153,19 @@
 //! assert_eq!(format!("{}", result), "7/4");  // Printed as fraction by default
 //! assert_eq!(format!("{:.2}", result), "1.75"); // if precision is defined, printed as decimal
 //! assert_eq!(format!("{:#.3}", result), "1.750"); // to print leading zeroes, pass hash to the format
+//! ```
+//!
+//! Additionally, there are [methods](GenericFraction::get_unicode_display) available for various unicode display options:
+//! See [this SO answer](https://stackoverflow.com/a/77861320/14681457) for a discussion.
+//!
+//! ```
+//! type F = fraction::Fraction;
+//!
+//! let res = F::from(0.7) / F::from(0.4);
+//! assert_eq!("7⁄4",format!("{}", res.get_unicode_display())); // needs font support. Unicode way
+//! assert_eq!("1⁤3⁄4",format!("{}", res.get_unicode_display().mixed())); // interpreted wrongly without font support
+//! assert_eq!("⁷/₄",format!("{}", res.get_unicode_display().supsub())); // no need for font support
+//! assert_eq!("1³/₄",format!("{}", res.get_unicode_display().supsub().mixed()));
 //! ```
 //!
 //! ## Convert into/from other types


### PR DESCRIPTION
outlined in #100 Which character to use for the slash in output may be discussed, but I chose "FRACTION SLASH" since it's "fraction" crate.