### PR TITLE
Add ConstOne and ConstZero implementation

### DIFF
--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -1264,7 +1264,7 @@ mod tests {
     #[cfg(feature = "with-bigint")]
     use crate::{BigInt, BigUint};
 
-    use crate::{Bounded, Fraction, GenericFraction, Num, One, Sign, Signed, ToPrimitive, Zero};
+    use crate::{Bounded, ConstOne, ConstZero, Fraction, GenericFraction, Num, One, Sign, Signed, ToPrimitive, Zero};
 
     use super::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
 
@@ -2709,6 +2709,20 @@ mod tests {
         }
     }
 
+    #[test]
+    fn constant_one() {
+        let constant_one = <Frac as ConstOne>::ONE;
+        let one = Frac::one();
+        assert_eq!(constant_one, one);
+    }
+    
+    #[test]
+    fn constant_zero() {
+        let constant_zero = <Frac as ConstZero>::ZERO;
+        let zero = Frac::zero();
+        assert_eq!(constant_zero, zero);
+    }
+    
     #[test]
     fn consistency_partial_cmp() {
         let nan = Frac::nan();

--- a/src/fraction/generic_fraction.rs
+++ b/src/fraction/generic_fraction.rs
@@ -1,6 +1,6 @@
 use crate::fraction::Sign;
 use crate::{
-    display, Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Integer, Num,
+    display, Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, ConstOne, ConstZero, FromPrimitive, Integer, Num,
     One, ParseRatioError, Ratio, Signed, ToPrimitive, Zero,
 };
 #[cfg(feature = "with-bigint")]
@@ -594,10 +594,18 @@ impl<T: Clone + Integer> Zero for GenericFraction<T> {
     }
 }
 
+impl<T: ConstOne + ConstZero + Integer + Clone> ConstZero for GenericFraction<T> {
+    const ZERO: GenericFraction<T> = GenericFraction::Rational(Sign::Plus, Ratio::new_raw(ConstZero::ZERO, ConstOne::ONE));
+}
+
 impl<T: Clone + Integer> One for GenericFraction<T> {
     fn one() -> Self {
         GenericFraction::Rational(Sign::Plus, Ratio::one())
     }
+}
+
+impl<T: ConstOne + Integer + Clone> ConstOne for GenericFraction<T> {
+	const ONE: GenericFraction<T> = GenericFraction::Rational(Sign::Plus, Ratio::new_raw(ConstOne::ONE, ConstOne::ONE));
 }
 
 impl<T: Clone + Integer> Num for GenericFraction<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ pub use num::rational::{ParseRatioError, Ratio};
 
 pub use num::{
     Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Integer, Num, One,
-    Signed, ToPrimitive, Zero,
+    Signed, ToPrimitive, traits::{ConstOne, ConstZero}, Zero,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
Solves  #104 

The implementation requires extra trait bounds on the generic `T` since the traits `ConstOne` and `ConstZero` are not required for the trait `Integer`.
This is because types that require allocations should not implement `ConstOne` and `ConstZero`.
For example, arbitrary precision numbers.

I added the bounds of `ConstOne` or `ConstZero` where needed.