### PR TITLE
Specify minimal versions for dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,18 +27,18 @@ opt-level = 3
 
 [dependencies]
 
-num = { version = "0.4", default-features = false }
+num = { version = "0.4.2", default-features = false }
 
-byteorder = { version = "1", optional = true }
-bytes = { version = "1", optional = true }
-postgres-types = { version = "0.2", optional = true }
+byteorder = { version = "1.1", optional = true }
+bytes = { version = "1.0", optional = true }
+postgres-types = { version = "0.2.0", optional = true }
 
-serde = { version = "1", optional = true }
-serde_derive = { version = "1", optional = true }
+serde = { version = "1.0.157", optional = true }
+serde_derive = { version = "1.0.157", optional = true }
 
-juniper = { version = "0.15", optional = true }
+juniper = { version = "0.15.0", optional = true }
 
-lazy_static = { version = "1", optional = true }
+lazy_static = { version = "1.4", optional = true }
 
 
 [features]
@@ -56,7 +56,7 @@ with-serde-support = ["serde", "serde_derive", "num/serde"]
 with-unicode = []
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.4.0"
 rand = "0.8.5"
 
 [[bench]]


### PR DESCRIPTION
`fraction` is a transitive dependency in one of my projects and an upgrade to 0.15.2 broke the CI build due to wrongly specified minimal versions.

```
   Compiling fraction v0.15.2
error[E0432]: unresolved imports `num::traits::ConstOne`, `num::traits::ConstZero`
Error:    --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/fraction-0.15.2/src/lib.rs:227:14
    |
227 |     traits::{ConstOne, ConstZero},
    |              ^^^^^^^^  ^^^^^^^^^ no `ConstZero` in `traits`
    |              |
    |              no `ConstOne` in `traits`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `fraction` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.
```

`fraction` 0.15.2 makes use of traits that are only available in `num` 0.4.2+ but itself specifies support with `num` 0.4.0.
https://github.com/dnsl48/fraction/blob/338d056ef6ae4c4785d1f39b4810bb0d07f73fb6/Cargo.toml#L30

I added a minor version component to all dependencies in `Cargo.toml`. for `serde` and related crates the patch version is important.