### PR TITLE
Remove `lazy_static` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "fraction"
 version = "0.15.4"
 authors = ["dnsl48 <dnsl48@gmail.com>"]
 edition = "2015"
+rust-version = "1.70"
 
 description = "Lossless fractions and decimals; drop-in float replacement"
 keywords = ["fraction", "decimal", "float", "numeric"]
@@ -30,6 +31,8 @@ opt-level = 3
 
 num = { version = "0.4.3", default-features = false }
 
+num-bigint = { version = "0.4.8", optional = true }
+
 byteorder = { version = "1", optional = true }
 bytes = { version = "1", optional = true }
 postgres-types = { version = "0.2", optional = true }
@@ -39,13 +42,11 @@ serde_derive = { version = "1", optional = true }
 
 juniper = { version = "0.15", optional = true }
 
-lazy_static = { version = "1", optional = true }
-
 
 [features]
 default = ["with-bigint", "with-decimal", "with-dynaint"]
 
-with-bigint = ["num/num-bigint", "num/std", "lazy_static"]
+with-bigint = ["num/num-bigint", "num/std", "num-bigint"]
 with-decimal = []
 with-dynaint = []
 with-approx = ["with-bigint"]

--- a/src/fraction/approx.rs
+++ b/src/fraction/approx.rs
@@ -134,7 +134,7 @@ impl Accuracy {
     /// Returns a reference to the multiplier used by `self` to chop off irrelevant digits.
     #[must_use]
     pub fn multiplier(&self) -> &BigUint {
-        return match self {
+        match self {
             #[cfg(feature = "with-bigint")]
             Accuracy::Dp20 => {
                 static DP20_MUL: std::sync::OnceLock<BigUint> = std::sync::OnceLock::new();
@@ -151,6 +151,6 @@ impl Accuracy {
                 DP500_MUL.get_or_init(|| BigUint::from(10_u8).pow(500_u32))
             }
             Accuracy::Custom { multiplier } => multiplier,
-        };
+        }
     }
 }

--- a/src/fraction/approx.rs
+++ b/src/fraction/approx.rs
@@ -16,16 +16,16 @@ pub mod sqrt;
 #[derive(Clone, Debug, Default)]
 pub enum Accuracy {
     /// At least 20 digits correct after the decimal point.
-    #[cfg(feature = "lazy_static")]
+    #[cfg(feature = "with-bigint")]
     Dp20,
 
     /// At least 100 digits correct after the decimal point.
-    #[cfg(feature = "lazy_static")]
+    #[cfg(feature = "with-bigint")]
     #[default]
     Dp100,
 
     /// At least 500 digits correct after the decimal point.
-    #[cfg(feature = "lazy_static")]
+    #[cfg(feature = "with-bigint")]
     Dp500,
 
     /// An arbitrary number of correct digits.
@@ -51,7 +51,7 @@ impl Accuracy {
         BigUint: Pow<N>,
         <BigUint as Pow<N>>::Output: Into<BigUint>,
     {
-        #[cfg(feature = "lazy_static")]
+        #[cfg(feature = "with-bigint")]
         {
             // If we have access to pre-allocated `Accuracy` values, use them instead of allocating
             // a new multiplier.
@@ -134,32 +134,23 @@ impl Accuracy {
     /// Returns a reference to the multiplier used by `self` to chop off irrelevant digits.
     #[must_use]
     pub fn multiplier(&self) -> &BigUint {
-        #[cfg(feature = "lazy_static")]
-        {
-            lazy_static! {
-                static ref DP20_MUL: BigUint = BigUint::from(10_u8).pow(20_u32);
-                static ref DP100_MUL: BigUint = BigUint::from(10_u8).pow(100_u32);
-                static ref DP500_MUL: BigUint = BigUint::from(10_u8).pow(500_u32);
-            };
-
-            return match self {
-                Accuracy::Dp20 => &DP20_MUL,
-                Accuracy::Dp100 => &DP100_MUL,
-                Accuracy::Dp500 => &DP500_MUL,
-                Accuracy::Custom { multiplier } => multiplier,
-            };
-        }
-
-        // When `lazy_static` is enabled, this gets flagged as unreachable which it technically is,
-        // but *only* when `lazy_static` is on.
-        #[allow(unreachable_code)]
-        {
-            let Accuracy::Custom { multiplier } = self else {
-                // `Custom` is the only available variant when `lazy_static` is off.
-                unreachable!()
-            };
-
-            multiplier
-        }
+        return match self {
+            #[cfg(feature = "with-bigint")]
+            Accuracy::Dp20 => {
+                static DP20_MUL: std::sync::OnceLock<BigUint> = std::sync::OnceLock::new();
+                DP20_MUL.get_or_init(|| BigUint::from(10_u8).pow(20_u32))
+            }
+            #[cfg(feature = "with-bigint")]
+            Accuracy::Dp100 => {
+                static DP100_MUL: std::sync::OnceLock<BigUint> = std::sync::OnceLock::new();
+                DP100_MUL.get_or_init(|| BigUint::from(10_u8).pow(100_u32))
+            }
+            #[cfg(feature = "with-bigint")]
+            Accuracy::Dp500 => {
+                static DP500_MUL: std::sync::OnceLock<BigUint> = std::sync::OnceLock::new();
+                DP500_MUL.get_or_init(|| BigUint::from(10_u8).pow(500_u32))
+            }
+            Accuracy::Custom { multiplier } => multiplier,
+        };
     }
 }

--- a/src/fraction/approx/sqrt.rs
+++ b/src/fraction/approx/sqrt.rs
@@ -568,8 +568,9 @@ mod tests {
         );
     }
 
-    lazy_static! {
-        static ref VALUES: [BigFraction; 5] = [
+    #[test]
+    fn test_raw() {
+        let values: [BigFraction; 5] = [
             BigFraction::from(2),
             BigFraction::from(123_654),
             BigFraction::from(123_655),
@@ -578,18 +579,15 @@ mod tests {
             727314244020586751748892724760644\
             /\
             478953213143537128483961697945367179924659061093095449962100933428918126\
-            6216833845985099376094324166"
+            6216833845985099376094324166",
             )
             .unwrap(),
             BigFraction::from(0.2),
         ];
-    }
 
-    const ACCURACIES: [usize; 5] = [10, 100, 1000, 10000, 100_000];
+        const ACCURACIES: [usize; 5] = [10, 100, 1000, 10000, 100_000];
 
-    #[test]
-    fn test_raw() {
-        for value in &*VALUES {
+        for value in &values {
             for accuracy in ACCURACIES {
                 println!("sqrt({value}) to {accuracy} d.p., unsimplified");
                 test_sqrt_of(value, false, accuracy);

--- a/src/fraction/juniper_support.rs
+++ b/src/fraction/juniper_support.rs
@@ -87,7 +87,7 @@ where
     T: Clone + GenericInteger,
 {
     fn to_input_value(&self) -> ::juniper::InputValue<S> {
-        ::juniper::ToInputValue::to_input_value(&format!("{:+}", &self))
+        ::juniper::ToInputValue::to_input_value(&format!("{:+}", self))
     }
 }
 impl<S, T> ::juniper::FromInputValue<S> for GenericFraction<T>

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -9,7 +9,7 @@ use std::{any::TypeId, cmp::PartialOrd};
 use Sign;
 
 #[cfg(feature = "with-bigint")]
-use super::{BigInt, BigUint, One, Signed, Zero};
+use super::{BigInt, BigUint, Signed};
 
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign};
 
@@ -69,39 +69,32 @@ pub trait GenericInteger:
 }
 
 #[cfg(feature = "with-bigint")]
-lazy_static! {
-    static ref _0_BU: BigUint = BigUint::zero();
-    static ref _1_BU: BigUint = BigUint::one();
-    static ref _10_BU: BigUint = BigUint::from(10u8);
-    static ref _0_BI: BigInt = BigInt::zero();
-    static ref _1_BI: BigInt = BigInt::one();
-    static ref _10_BI: BigInt = BigInt::from(10i8);
-}
-
-#[cfg(feature = "with-bigint")]
 impl GenericInteger for BigUint {
     #[inline]
     fn _0() -> Self {
-        BigUint::zero()
+        BigUint::ZERO
     }
     #[inline]
     fn _1() -> Self {
-        BigUint::one()
+        BigUint::ONE
     }
     #[inline]
     fn _10() -> Self {
-        _10_BU.clone()
+        BigUint::new_const(10u32)
     }
     #[inline]
     fn _0r() -> Option<&'static Self> {
+        static _0_BU: BigUint = BigUint::ZERO;
         Some(&_0_BU)
     }
     #[inline]
     fn _1r() -> Option<&'static Self> {
+        static _1_BU: BigUint = BigUint::ONE;
         Some(&_1_BU)
     }
     #[inline]
     fn _10r() -> Option<&'static Self> {
+        static _10_BU: BigUint = BigUint::new_const(10u32);
         Some(&_10_BU)
     }
 
@@ -115,26 +108,29 @@ impl GenericInteger for BigUint {
 impl GenericInteger for BigInt {
     #[inline]
     fn _0() -> Self {
-        BigInt::zero()
+        BigInt::ZERO
     }
     #[inline]
     fn _1() -> Self {
-        BigInt::one()
+        BigInt::ONE
     }
     #[inline]
     fn _10() -> Self {
-        _10_BI.clone()
+        BigInt::new_const(10i32)
     }
     #[inline]
     fn _0r() -> Option<&'static Self> {
+        static _0_BI: BigInt = BigInt::ZERO;
         Some(&_0_BI)
     }
     #[inline]
     fn _1r() -> Option<&'static Self> {
+        static _1_BI: BigInt = BigInt::ONE;
         Some(&_1_BI)
     }
     #[inline]
     fn _10r() -> Option<&'static Self> {
+        static _10_BI: BigInt = BigInt::new_const(10i32);
         Some(&_10_BI)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,10 +218,6 @@
 extern crate num;
 
 #[cfg(feature = "with-bigint")]
-#[macro_use]
-extern crate lazy_static;
-
-#[cfg(feature = "with-bigint")]
 pub use num::bigint::{BigInt, BigUint};
 
 pub use num::rational::{ParseRatioError, Ratio};


### PR DESCRIPTION
The MSRV is set to 1.70 in order to have access to `std::sync::OnceLock`.

`num-bigint` was added in order to get a more recent version, because the version included in `num/num-bigint` does not have the `const` constructors.